### PR TITLE
feat: Use runpod/worker-comfyui base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,103 +1,36 @@
-# Use multi-stage build with caching optimizations
-FROM nvidia/cuda:12.8.1-cudnn-devel-ubuntu24.04 AS base
+# Step 1: Start from the official RunPod ComfyUI base image.
+# Using '-base' gives us a clean slate without extra models.
+FROM runpod/worker-comfyui:5.1.0-base
 
-# Consolidated environment variables
-ENV DEBIAN_FRONTEND=noninteractive \
-   PIP_PREFER_BINARY=1 \
-   PYTHONUNBUFFERED=1 \
-   CMAKE_BUILD_PARALLEL_LEVEL=8
+# Step 2: Install the custom nodes needed for video generation.
+# This uses the 'comfy-node-install' tool that comes with the base image.
+RUN comfy-node-install ComfyUI-AnimateDiff-Evolved ComfyUI-VideoHelperSuite ComfyUI-Manager
 
-RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
-    apt-get update && \
-    apt-get install -y --no-install-recommends \
-        python3.12 python3.12-venv python3.12-dev \
-        python3-pip \
-        curl ffmpeg ninja-build git aria2 git-lfs wget vim \
-        libgl1 libglib2.0-0 build-essential gcc && \
-    \
-    # make Python3.12 the default python & pip
-    ln -sf /usr/bin/python3.12 /usr/bin/python && \
-    ln -sf /usr/bin/pip3 /usr/bin/pip && \
-    \
-    python3.12 -m venv /opt/venv && \
-    \
-    apt-get clean && rm -rf /var/lib/apt/lists/*
+# Step 3: Download the necessary models using the 'comfy model download' tool.
+# We need the main AnimateDiff model and a motion module.
 
-# Use the virtual environment
-ENV PATH="/opt/venv/bin:$PATH"
+# AnimateDiff V3 Model
+RUN comfy model download --url https://huggingface.co/guoyww/animatediff/resolve/main/mm_sd_v15_v2.ckpt \
+                         --relative-path models/animatediff_models \
+                         --filename mm_sd_v15_v2.ckpt
 
-RUN --mount=type=cache,target=/root/.cache/pip \
-    pip install --pre torch torchvision torchaudio \
-        --index-url https://download.pytorch.org/whl/nightly/cu128
+# A popular motion module for smoother animation
+RUN comfy model download --url https://huggingface.co/guoyww/animatediff/resolve/main/v3_sd15_mm.ckpt \
+                         --relative-path models/animatediff_models \
+                         --filename v3_sd15_mm.ckpt
 
-# Core Python tooling
-RUN --mount=type=cache,target=/root/.cache/pip \
-    pip install packaging setuptools wheel
+# A base checkpoint model to generate the video from (e.g., Realistic Vision)
+RUN comfy model download --url https://civitai.com/api/download/models/130072 \
+                         --relative-path models/checkpoints \
+                         --filename realisticVisionV60B1_v51VAE.safetensors
 
-# Runtime libraries
-RUN --mount=type=cache,target=/root/.cache/pip \
-    pip install pyyaml gdown triton comfy-cli jupyterlab jupyterlab-lsp \
-        jupyter-server jupyter-server-terminals \
-        ipykernel jupyterlab_code_formatter
+# --- Optional Steps (uncomment and use if needed) ---
 
-# ------------------------------------------------------------
-# ComfyUI install
-# ------------------------------------------------------------
-RUN --mount=type=cache,target=/root/.cache/pip \
-    /usr/bin/yes | comfy --workspace /ComfyUI install
+# If you need a specific LoRA, uncomment the line below
+# RUN comfy model download --url <URL_TO_YOUR_LORA> --relative-path models/loras --filename <YOUR_LORA_NAME>.safetensors
 
-FROM base AS final
-# Make sure to use the virtual environment here too
-ENV PATH="/opt/venv/bin:$PATH"
-RUN pip install opencv-python
-
-RUN for repo in \
-    https://github.com/ssitu/ComfyUI_UltimateSDUpscale.git \
-    https://github.com/kijai/ComfyUI-KJNodes.git \
-    https://github.com/rgthree/rgthree-comfy.git \
-    https://github.com/JPS-GER/ComfyUI_JPS-Nodes.git \
-    https://github.com/Suzie1/ComfyUI_Comfyroll_CustomNodes.git \
-    https://github.com/Jordach/comfy-plasma.git \
-    https://github.com/Kosinkadink/ComfyUI-VideoHelperSuite.git \
-    https://github.com/bash-j/mikey_nodes.git \
-    https://github.com/ltdrdata/ComfyUI-Impact-Pack.git \
-    https://github.com/Fannovel16/comfyui_controlnet_aux.git \
-    https://github.com/yolain/ComfyUI-Easy-Use.git \
-    https://github.com/kijai/ComfyUI-Florence2.git \
-    https://github.com/ShmuelRonen/ComfyUI-LatentSyncWrapper.git \
-    https://github.com/WASasquatch/was-node-suite-comfyui.git \
-    https://github.com/theUpsider/ComfyUI-Logic.git \
-    https://github.com/cubiq/ComfyUI_essentials.git \
-    https://github.com/chrisgoringe/cg-image-picker.git \
-    https://github.com/chflame163/ComfyUI_LayerStyle.git \
-    https://github.com/chrisgoringe/cg-use-everywhere.git \
-    https://github.com/ClownsharkBatwing/RES4LYF \
-    https://github.com/welltop-cn/ComfyUI-TeaCache.git \
-    https://github.com/Fannovel16/ComfyUI-Frame-Interpolation.git \
-    https://github.com/Jonseed/ComfyUI-Detail-Daemon.git \
-    https://github.com/kijai/ComfyUI-WanVideoWrapper.git \
-    https://github.com/chflame163/ComfyUI_LayerStyle_Advance.git \
-    https://github.com/BadCafeCode/masquerade-nodes-comfyui.git \
-    https://github.com/1038lab/ComfyUI-RMBG.git \
-    https://github.com/M1kep/ComfyLiterals.git; \
-    do \
-        cd /ComfyUI/custom_nodes; \
-        repo_dir=$(basename "$repo" .git); \
-        if [ "$repo" = "https://github.com/ssitu/ComfyUI_UltimateSDUpscale.git" ]; then \
-            git clone --recursive "$repo"; \
-        else \
-            git clone "$repo"; \
-        fi; \
-        if [ -f "/ComfyUI/custom_nodes/$repo_dir/requirements.txt" ]; then \
-            pip install -r "/ComfyUI/custom_nodes/$repo_dir/requirements.txt"; \
-        fi; \
-        if [ -f "/ComfyUI/custom_nodes/$repo_dir/install.py" ]; then \
-            python "/ComfyUI/custom_nodes/$repo_dir/install.py"; \
-        fi; \
-    done
-
-COPY src/start_script.sh /start_script.sh
-RUN chmod +x /start_script.sh
-COPY 4xLSDIR.pth /4xLSDIR.pth
-
-CMD ["/start_script.sh"]
+# If you need to add static input files (like an initial video or images)
+# 1. Create a folder named 'input' in your GitHub repo.
+# 2. Place your files inside it.
+# 3. Uncomment the line below.
+# COPY input/ /comfyui/input/


### PR DESCRIPTION
This commit updates the Dockerfile to use the official `runpod/worker-comfyui` base image. This base image includes a pre-built handler, which simplifies the setup significantly.

The new Dockerfile:
- Starts from `runpod/worker-comfyui:5.1.0-base`.
- Uses `comfy-node-install` to add necessary custom nodes (AnimateDiff, VideoHelperSuite, Manager).
- Uses `comfy model download` to fetch the required models for video generation.

The files `handler.py` and `requirements.txt` were not found in the repository and thus were not deleted.