### PR TITLE
start.sh: auto-download 1x-ITF skin-detail + rife426 frame-interpolation weights

### DIFF
--- a/src/start.sh
+++ b/src/start.sh
@@ -327,6 +327,22 @@ else
     echo "2xLiveActionV1_SPAN already exists. Skipping."
 fi
 
+# 1x-ITF-SkinDiffDetail-Lite-v1 — skin-detail restorer for the Wan Animate
+# flows. Direct download (OpenModelDB object storage, not on HF, so not part
+# of the model registry/provisioner).
+if [ "$download_wan_animate" = "true" ]; then
+    ITF_DEST="$NETWORK_VOLUME/ComfyUI/models/upscale_models/1x-ITF-SkinDiffDetail-Lite-v1.pth"
+    if [ ! -f "$ITF_DEST" ]; then
+        echo "Downloading 1x-ITF-SkinDiffDetail-Lite-v1..."
+        aria2c -x 8 -s 8 --console-log-level=warn --summary-interval=0 \
+            -d "$(dirname "$ITF_DEST")" -o "$(basename "$ITF_DEST")" \
+            "https://objectstorage.us-phoenix-1.oraclecloud.com/n/ax6ygfvpvzka/b/open-modeldb-files/o/1x-ITF-SkinDiffDetail-Lite-v1.pth" \
+            || echo "⚠️  1x-ITF-SkinDiffDetail-Lite-v1 download failed (continuing)"
+    else
+        echo "1x-ITF-SkinDiffDetail-Lite-v1 already exists. Skipping."
+    fi
+fi
+
 echo "Finished downloading models!"
 
 

--- a/src/start.sh
+++ b/src/start.sh
@@ -343,6 +343,21 @@ if [ "$download_wan_animate" = "true" ]; then
     fi
 fi
 
+# rife426 — RIFE VFI weights for the frame-interpolation (60FPS) flows.
+# Direct download (GitHub release asset, not on HF, so not part of the model
+# registry/provisioner).
+mkdir -p "$NETWORK_VOLUME/ComfyUI/models/frame_interpolation"
+RIFE_DEST="$NETWORK_VOLUME/ComfyUI/models/frame_interpolation/rife426.pth"
+if [ ! -f "$RIFE_DEST" ]; then
+    echo "Downloading rife426..."
+    aria2c -x 8 -s 8 --console-log-level=warn --summary-interval=0 \
+        -d "$(dirname "$RIFE_DEST")" -o "$(basename "$RIFE_DEST")" \
+        "https://github.com/Fannovel16/ComfyUI-Frame-Interpolation/releases/download/models/rife426.pth" \
+        || echo "⚠️  rife426 download failed (continuing)"
+else
+    echo "rife426 already exists. Skipping."
+fi
+
 echo "Finished downloading models!"
 
 


### PR DESCRIPTION
Two models the Wan flows expect but the boot script never fetched.

- `1x-ITF-SkinDiffDetail-Lite-v1.pth` -> `models/upscale_models`, gated on `download_wan_animate=true` (OpenModelDB object storage).
- `rife426.pth` -> `models/frame_interpolation`, unconditional — RIFE VFI is used by the 60FPS workflows across Wan 2.1, Wan 2.2, Steady Dancer and Wan Animate (GitHub release asset).

Neither is on HuggingFace, so both take the existing direct-download path (`aria2c`, non-fatal on failure, skipped when the file is already on the volume) rather than the model registry/provisioner — same shape as the `2xLiveActionV1_SPAN` block above them.

Verified with `bash -n`, `shellcheck` (zero findings in the new blocks), and out-of-tree gate tests against a stubbed `aria2c` proving the flag gating, the exact URLs, and idempotence on rerun. Both URLs return 200 (20 MB / 24 MB).

Closes HEA-84.