### PR TITLE
workflows: ship the Wan 2.2 SVI 4-pass flows (V1 + V3)

### DIFF
--- a/src/models_registry.json
+++ b/src/models_registry.json
@@ -1,4 +1,8 @@
 {
+  "4x-ClearRealityV1_Soft.pth": {
+    "url": "https://huggingface.co/Kim2091/ClearRealityV1/resolve/main/4x-ClearRealityV1_Soft.pth",
+    "subdir": "upscale_models"
+  },
   "SVI_v2_PRO_Wan2.2-I2V-A14B_HIGH_lora_rank_128_fp16.safetensors": {
     "url": "https://huggingface.co/Kijai/WanVideo_comfy/resolve/main/LoRAs/Stable-Video-Infinity/v2.0/SVI_v2_PRO_Wan2.2-I2V-A14B_HIGH_lora_rank_128_fp16.safetensors",
     "subdir": "loras"
@@ -41,6 +45,10 @@
   },
   "i2v_lightx2v_low_noise_model.safetensors": {
     "url": "https://huggingface.co/lightx2v/Wan2.2-Distill-Loras/resolve/main/wan2.2_i2v_A14b_low_noise_lora_rank64_lightx2v_4step_1022.safetensors",
+    "subdir": "loras"
+  },
+  "lightx2v_I2V_14B_480p_cfg_step_distill_rank128_bf16.safetensors": {
+    "url": "https://huggingface.co/Kijai/WanVideo_comfy/resolve/main/Lightx2v/lightx2v_I2V_14B_480p_cfg_step_distill_rank128_bf16.safetensors",
     "subdir": "loras"
   },
   "lightx2v_I2V_14B_480p_cfg_step_distill_rank64_bf16.safetensors": {
@@ -123,6 +131,10 @@
   "wan_2.1_vae.safetensors": {
     "url": "https://huggingface.co/Comfy-Org/Wan_2.1_ComfyUI_repackaged/resolve/main/split_files/vae/wan_2.1_vae.safetensors",
     "subdir": "vae"
+  },
+  "x1_ITF_SkinDiffDDS_v1.pth": {
+    "url": "https://huggingface.co/GritTin/modelsStableDiffusion/resolve/main/x1_ITF_SkinDiffDDS_v1.pth",
+    "subdir": "upscale_models"
   },
   "yolov10m.onnx": {
     "url": "https://huggingface.co/Wan-AI/Wan2.2-Animate-14B/resolve/main/process_checkpoint/det/yolov10m.onnx",

--- a/workflows/Wan 2.2/Video Generation/SVI 4-pass/HearmemanAI_Wan2.2_SVI_4pass.json
+++ b/workflows/Wan 2.2/Video Generation/SVI 4-pass/HearmemanAI_Wan2.2_SVI_4pass.json
@@ -1,0 +1,11499 @@
+{
+  "id": "5a452388-8c0c-42ad-8122-907a29bf650b",
+  "revision": 0,
+  "last_node_id": 998,
+  "last_link_id": 1279,
+  "nodes": [
+    {
+      "id": 315,
+      "type": "SetNode",
+      "pos": [
+        -343.912081719989,
+        -354.84178997119466
+      ],
+      "size": [
+        231.2447265625,
+        58
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 88,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "FLOAT",
+          "type": "FLOAT",
+          "link": 1026
+        }
+      ],
+      "outputs": [
+        {
+          "name": "*",
+          "type": "*",
+          "links": null
+        }
+      ],
+      "title": "Set_cfg ksampler nolightning",
+      "properties": {
+        "previousName": "cfg ksampler nolightning",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "cfg ksampler nolightning"
+      ],
+      "color": "#232",
+      "bgcolor": "#353"
+    },
+    {
+      "id": 277,
+      "type": "SetNode",
+      "pos": [
+        -348.7274495715511,
+        -525.0505331743198
+      ],
+      "size": [
+        240.45767939843017,
+        58.98474402005235
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 85,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "INT",
+          "type": "INT",
+          "link": 1028
+        }
+      ],
+      "outputs": [
+        {
+          "name": "*",
+          "type": "*",
+          "links": null
+        }
+      ],
+      "title": "Set_no lightning end step",
+      "properties": {
+        "previousName": "no lightning end step",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "no lightning end step"
+      ],
+      "color": "#1b4669",
+      "bgcolor": "#29699c"
+    },
+    {
+      "id": 279,
+      "type": "SetNode",
+      "pos": [
+        -663.912790782488,
+        -357.473610869632
+      ],
+      "size": [
+        219.1451171875,
+        58
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 87,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "INT",
+          "type": "INT",
+          "link": 1029
+        }
+      ],
+      "outputs": [
+        {
+          "name": "*",
+          "type": "*",
+          "links": null
+        }
+      ],
+      "title": "Set_lightning high end step",
+      "properties": {
+        "previousName": "lightning high end step",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "lightning high end step"
+      ],
+      "color": "#1b4669",
+      "bgcolor": "#29699c"
+    },
+    {
+      "id": 146,
+      "type": "GetNode",
+      "pos": [
+        82.8227289056705,
+        -923.6241340731874
+      ],
+      "size": [
+        210,
+        60
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 0,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "LATENT",
+          "type": "LATENT",
+          "links": [
+            1223
+          ]
+        }
+      ],
+      "title": "Get_anchor sample",
+      "properties": {
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "anchor sample"
+      ],
+      "color": "#323",
+      "bgcolor": "#535"
+    },
+    {
+      "id": 200,
+      "type": "GetNode",
+      "pos": [
+        94.06047007624511,
+        -474.5010713982689
+      ],
+      "size": [
+        210,
+        58
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 1,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "LATENT",
+          "type": "LATENT",
+          "links": [
+            1209
+          ]
+        }
+      ],
+      "title": "Get_anchor sample",
+      "properties": {
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "anchor sample"
+      ],
+      "color": "#323",
+      "bgcolor": "#535"
+    },
+    {
+      "id": 138,
+      "type": "SetNode",
+      "pos": [
+        -220.01939136842626,
+        -1008.8136486430703
+      ],
+      "size": [
+        268.2134765625,
+        58
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 103,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "link": 1014
+        }
+      ],
+      "outputs": [
+        {
+          "name": "*",
+          "type": "*",
+          "links": null
+        }
+      ],
+      "title": "Set_load image (perfectresolution)",
+      "properties": {
+        "previousName": "load image (perfectresolution)",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "load image (perfectresolution)"
+      ],
+      "color": "#2a363b",
+      "bgcolor": "#3f5159"
+    },
+    {
+      "id": 139,
+      "type": "GetNode",
+      "pos": [
+        -218.27900074342634,
+        -963.0688439555706
+      ],
+      "size": [
+        269.6763671875,
+        60
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 2,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": [
+            1021
+          ]
+        }
+      ],
+      "title": "Get_load image (perfectresolution)",
+      "properties": {
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "load image (perfectresolution)"
+      ],
+      "color": "#2a363b",
+      "bgcolor": "#3f5159"
+    },
+    {
+      "id": 131,
+      "type": "GetNode",
+      "pos": [
+        -214.8758757434263,
+        -912.6235314555706
+      ],
+      "size": [
+        210,
+        58
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 3,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "VAE",
+          "type": "VAE",
+          "links": [
+            1022
+          ]
+        }
+      ],
+      "title": "Get_load vae",
+      "properties": {
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "load vae"
+      ],
+      "color": "#322",
+      "bgcolor": "#533"
+    },
+    {
+      "id": 145,
+      "type": "SetNode",
+      "pos": [
+        -186.26091480592598,
+        -769.5268517680709
+      ],
+      "size": [
+        210,
+        60
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 96,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "LATENT",
+          "type": "LATENT",
+          "link": 1023
+        }
+      ],
+      "outputs": [
+        {
+          "name": "*",
+          "type": "*",
+          "links": null
+        }
+      ],
+      "title": "Set_anchor sample",
+      "properties": {
+        "previousName": "anchor sample",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "anchor sample"
+      ],
+      "color": "#323",
+      "bgcolor": "#535"
+    },
+    {
+      "id": 354,
+      "type": "SetNode",
+      "pos": [
+        -2595.0537109375005,
+        -268.58421875000005
+      ],
+      "size": [
+        210,
+        34
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 81,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "CLIP",
+          "type": "CLIP",
+          "link": 1003
+        }
+      ],
+      "outputs": [
+        {
+          "name": "*",
+          "type": "*",
+          "links": null
+        }
+      ],
+      "title": "Set_load clip",
+      "properties": {
+        "previousName": "load clip",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "load clip"
+      ],
+      "color": "#432",
+      "bgcolor": "#653"
+    },
+    {
+      "id": 352,
+      "type": "SetNode",
+      "pos": [
+        -2714.5412109375,
+        -129.2804296875
+      ],
+      "size": [
+        210,
+        34
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 75,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "VAE",
+          "type": "VAE",
+          "link": 1004
+        }
+      ],
+      "outputs": [
+        {
+          "name": "*",
+          "type": "*",
+          "links": null
+        }
+      ],
+      "title": "Set_load vae",
+      "properties": {
+        "previousName": "load vae",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "load vae"
+      ],
+      "color": "#322",
+      "bgcolor": "#533"
+    },
+    {
+      "id": 113,
+      "type": "SetNode",
+      "pos": [
+        -2595.988828124999,
+        -611.2327343750003
+      ],
+      "size": [
+        210,
+        58
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 94,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "link": 1268
+        }
+      ],
+      "outputs": [
+        {
+          "name": "*",
+          "type": "*",
+          "links": null
+        }
+      ],
+      "title": "Set_model high",
+      "properties": {
+        "previousName": "model high",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "model high"
+      ],
+      "color": "#223",
+      "bgcolor": "#335"
+    },
+    {
+      "id": 114,
+      "type": "SetNode",
+      "pos": [
+        -2587.9962109375015,
+        -502.8784765625001
+      ],
+      "size": [
+        210,
+        58
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 93,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "link": 1269
+        }
+      ],
+      "outputs": [
+        {
+          "name": "*",
+          "type": "*",
+          "links": null
+        }
+      ],
+      "title": "Set_model low",
+      "properties": {
+        "previousName": "model low",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "model low"
+      ],
+      "color": "#223",
+      "bgcolor": "#335"
+    },
+    {
+      "id": 880,
+      "type": "ModelSamplingSD3",
+      "pos": [
+        -2350.165351562502,
+        -591.8538281250001
+      ],
+      "size": [
+        210,
+        34
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 79,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "model",
+          "type": "MODEL",
+          "link": 1005
+        }
+      ],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "slot_index": 0,
+          "links": [
+            1006
+          ]
+        }
+      ],
+      "title": "High model shift",
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.3.45",
+        "Node name for S&R": "ModelSamplingSD3",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.1",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        8
+      ],
+      "color": "#223",
+      "bgcolor": "#335"
+    },
+    {
+      "id": 121,
+      "type": "GetNode",
+      "pos": [
+        -2366.448203125,
+        -266.07769531249994
+      ],
+      "size": [
+        210,
+        58
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 4,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": [
+            1010
+          ]
+        }
+      ],
+      "title": "Get_model low",
+      "properties": {
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "model low"
+      ],
+      "color": "#223",
+      "bgcolor": "#335"
+    },
+    {
+      "id": 367,
+      "type": "SetNode",
+      "pos": [
+        -1945.4033593749991,
+        -517.4624609374999
+      ],
+      "size": [
+        210,
+        34
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 111,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "link": 1008
+        }
+      ],
+      "outputs": [
+        {
+          "name": "*",
+          "type": "*",
+          "links": null
+        }
+      ],
+      "title": "Set_lora high svi",
+      "properties": {
+        "previousName": "lora high svi",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "lora high svi"
+      ],
+      "color": "#223",
+      "bgcolor": "#335"
+    },
+    {
+      "id": 881,
+      "type": "LoraLoaderModelOnly",
+      "pos": [
+        -2378.940312499998,
+        -550.0757421875002
+      ],
+      "size": [
+        381.14311789279077,
+        82
+      ],
+      "flags": {},
+      "order": 101,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "model",
+          "type": "MODEL",
+          "link": 1006
+        }
+      ],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": [
+            1007,
+            1008
+          ]
+        }
+      ],
+      "title": "SVI high LoRA",
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.8.0",
+        "Node name for S&R": "LoraLoaderModelOnly",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "SVI_v2_PRO_Wan2.2-I2V-A14B_HIGH_lora_rank_128_fp16.safetensors",
+        1
+      ],
+      "color": "#223",
+      "bgcolor": "#335"
+    },
+    {
+      "id": 883,
+      "type": "LoraLoaderModelOnly",
+      "pos": [
+        -2384.549257812499,
+        -419.6178906250003
+      ],
+      "size": [
+        381.8711403358735,
+        83.01525597994748
+      ],
+      "flags": {},
+      "order": 110,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "model",
+          "type": "MODEL",
+          "link": 1007
+        }
+      ],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": [
+            1009
+          ]
+        }
+      ],
+      "title": "SVI lightning high LoRA",
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.8.0",
+        "Node name for S&R": "LoraLoaderModelOnly",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "lightx2v_I2V_14B_480p_cfg_step_distill_rank128_bf16.safetensors",
+        4
+      ],
+      "color": "#223",
+      "bgcolor": "#335"
+    },
+    {
+      "id": 882,
+      "type": "LoraLoaderModelOnly",
+      "pos": [
+        -2386.587890625,
+        -210.43660156250047
+      ],
+      "size": [
+        387.5635967099787,
+        82
+      ],
+      "flags": {},
+      "order": 74,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "model",
+          "type": "MODEL",
+          "link": 1010
+        }
+      ],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": [
+            1011
+          ]
+        }
+      ],
+      "title": "SVI low LoRA",
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.8.0",
+        "Node name for S&R": "LoraLoaderModelOnly",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "SVI_v2_PRO_Wan2.2-I2V-A14B_LOW_lora_rank_128_fp16.safetensors",
+        1
+      ],
+      "color": "#223",
+      "bgcolor": "#335"
+    },
+    {
+      "id": 884,
+      "type": "LoraLoaderModelOnly",
+      "pos": [
+        -2391.6721874999985,
+        -80.69246093750037
+      ],
+      "size": [
+        385.8691344794463,
+        82
+      ],
+      "flags": {},
+      "order": 97,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "model",
+          "type": "MODEL",
+          "link": 1011
+        }
+      ],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": [
+            1012
+          ]
+        }
+      ],
+      "title": "SVI lightning low LoRA",
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.8.0",
+        "Node name for S&R": "LoraLoaderModelOnly",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "i2v_lightx2v_low_noise_model.safetensors",
+        1.4
+      ],
+      "color": "#223",
+      "bgcolor": "#335"
+    },
+    {
+      "id": 225,
+      "type": "VAELoader",
+      "pos": [
+        -2973.958671875,
+        -150.33253906250008
+      ],
+      "size": [
+        210,
+        58
+      ],
+      "flags": {
+        "collapsed": false
+      },
+      "order": 5,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "VAE",
+          "type": "VAE",
+          "slot_index": 0,
+          "links": [
+            1004
+          ]
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.3.45",
+        "Node name for S&R": "VAELoader",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        },
+        "models": [
+          {
+            "name": "wan_2.1_vae.safetensors",
+            "url": "https://huggingface.co/Comfy-Org/Wan_2.2_ComfyUI_Repackaged/resolve/main/split_files/vae/wan_2.1_vae.safetensors",
+            "directory": "vae"
+          }
+        ]
+      },
+      "widgets_values": [
+        "wan_2.1_vae.safetensors"
+      ],
+      "color": "#223",
+      "bgcolor": "#335"
+    },
+    {
+      "id": 358,
+      "type": "SetNode",
+      "pos": [
+        -2189.6592968749987,
+        -268.5892578125003
+      ],
+      "size": [
+        241.6080078125,
+        34
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 114,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "link": 1009
+        }
+      ],
+      "outputs": [
+        {
+          "name": "*",
+          "type": "*",
+          "links": null
+        }
+      ],
+      "title": "Set_lora svi lightning high",
+      "properties": {
+        "previousName": "lora  svi lightning high",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "lora  svi lightning high"
+      ],
+      "color": "#223",
+      "bgcolor": "#335"
+    },
+    {
+      "id": 126,
+      "type": "GetNode",
+      "pos": [
+        -1672.1209375,
+        -626.6023437499999
+      ],
+      "size": [
+        210,
+        64.91383894294631
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 6,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": [
+            1030
+          ]
+        }
+      ],
+      "title": "Get_lora high svi",
+      "properties": {
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "lora high svi"
+      ],
+      "color": "#223",
+      "bgcolor": "#335"
+    },
+    {
+      "id": 129,
+      "type": "GetNode",
+      "pos": [
+        -1680.4396874999998,
+        -574.2445312499999
+      ],
+      "size": [
+        243.0708984375,
+        58
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 7,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": [
+            1031
+          ]
+        }
+      ],
+      "title": "Get_lora  svi lightning high",
+      "properties": {
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "lora  svi lightning high"
+      ],
+      "color": "#223",
+      "bgcolor": "#335"
+    },
+    {
+      "id": 128,
+      "type": "GetNode",
+      "pos": [
+        -1681.1142968749996,
+        -524.5292968749998
+      ],
+      "size": [
+        210,
+        58
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 8,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": [
+            1033
+          ]
+        }
+      ],
+      "title": "Get_lora svi lightning low",
+      "properties": {
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "lora svi lightning low"
+      ],
+      "color": "#223",
+      "bgcolor": "#335"
+    },
+    {
+      "id": 401,
+      "type": "SetNode",
+      "pos": [
+        -1344.443359375,
+        -331.767578125
+      ],
+      "size": [
+        224.5318359375,
+        58
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 99,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "link": 1095
+        }
+      ],
+      "outputs": [
+        {
+          "name": "*",
+          "type": "*",
+          "links": null
+        }
+      ],
+      "title": "Set_svi model lightning high",
+      "properties": {
+        "previousName": "svi model lightning high",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "svi model lightning high"
+      ],
+      "color": "#223",
+      "bgcolor": "#335"
+    },
+    {
+      "id": 400,
+      "type": "SetNode",
+      "pos": [
+        -1341.1863281249998,
+        -527.3703125000001
+      ],
+      "size": [
+        245.1353515625,
+        58
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 98,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "link": 1094
+        }
+      ],
+      "outputs": [
+        {
+          "name": "*",
+          "type": "*",
+          "links": null
+        }
+      ],
+      "title": "Set_svi model no lightning high",
+      "properties": {
+        "previousName": "svi model no lightning high",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "svi model no lightning high"
+      ],
+      "color": "#223",
+      "bgcolor": "#335"
+    },
+    {
+      "id": 402,
+      "type": "SetNode",
+      "pos": [
+        -1329.5847656250003,
+        -114.04453124999999
+      ],
+      "size": [
+        218.987890625,
+        58
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 100,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "link": 1096
+        }
+      ],
+      "outputs": [
+        {
+          "name": "*",
+          "type": "*",
+          "links": null
+        }
+      ],
+      "title": "Set_svi model lightning low",
+      "properties": {
+        "previousName": "svi model lightning low",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "svi model lightning low"
+      ],
+      "color": "#223",
+      "bgcolor": "#335"
+    },
+    {
+      "id": 410,
+      "type": "GetNode",
+      "pos": [
+        77.68281856452664,
+        -1057.4041540974902
+      ],
+      "size": [
+        246.5982421875,
+        60.92295998177042
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 9,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": [
+            1199,
+            1213
+          ]
+        }
+      ],
+      "title": "Get_svi model no lightning high",
+      "properties": {
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "svi model no lightning high"
+      ],
+      "color": "#223",
+      "bgcolor": "#335"
+    },
+    {
+      "id": 411,
+      "type": "GetNode",
+      "pos": [
+        80.17930293952665,
+        -1012.9186072224899
+      ],
+      "size": [
+        225.9947265625,
+        60.92295998177042
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 10,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": [
+            1203,
+            1217
+          ]
+        }
+      ],
+      "title": "Get_svi model lightning high",
+      "properties": {
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "svi model lightning high"
+      ],
+      "color": "#223",
+      "bgcolor": "#335"
+    },
+    {
+      "id": 412,
+      "type": "GetNode",
+      "pos": [
+        80.53594356452663,
+        -963.8139197224896
+      ],
+      "size": [
+        220.45078125,
+        60.92295998177042
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 11,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": [
+            1206,
+            1220
+          ]
+        }
+      ],
+      "title": "Get_svi model lightning low",
+      "properties": {
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "svi model lightning low"
+      ],
+      "color": "#223",
+      "bgcolor": "#335"
+    },
+    {
+      "id": 130,
+      "type": "GetNode",
+      "pos": [
+        84.0903070306705,
+        -879.026868448188
+      ],
+      "size": [
+        210,
+        60
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 12,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "VAE",
+          "type": "VAE",
+          "links": [
+            1219
+          ]
+        }
+      ],
+      "title": "Get_load vae",
+      "properties": {
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "load vae"
+      ],
+      "color": "#322",
+      "bgcolor": "#533"
+    },
+    {
+      "id": 316,
+      "type": "GetNode",
+      "pos": [
+        82.95593203067058,
+        -831.4217903231879
+      ],
+      "size": [
+        232.7076171875,
+        60
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 13,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "FLOAT",
+          "type": "FLOAT",
+          "links": [
+            1215
+          ]
+        }
+      ],
+      "title": "Get_cfg ksampler nolightning",
+      "properties": {
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "cfg ksampler nolightning"
+      ],
+      "color": "#232",
+      "bgcolor": "#353"
+    },
+    {
+      "id": 197,
+      "type": "GetNode",
+      "pos": [
+        94.81828257624511,
+        -431.727633898269
+      ],
+      "size": [
+        210,
+        58
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 14,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "VAE",
+          "type": "VAE",
+          "links": [
+            1205
+          ]
+        }
+      ],
+      "title": "Get_load vae",
+      "properties": {
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "load vae"
+      ],
+      "color": "#322",
+      "bgcolor": "#533"
+    },
+    {
+      "id": 317,
+      "type": "GetNode",
+      "pos": [
+        96.42375132624511,
+        -386.2901338982691
+      ],
+      "size": [
+        232.7076171875,
+        58
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 15,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "FLOAT",
+          "type": "FLOAT",
+          "links": [
+            1201
+          ]
+        }
+      ],
+      "title": "Get_cfg ksampler nolightning",
+      "properties": {
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "cfg ksampler nolightning"
+      ],
+      "color": "#232",
+      "bgcolor": "#353"
+    },
+    {
+      "id": 308,
+      "type": "GetNode",
+      "pos": [
+        99.68547007624512,
+        -338.09091514826963
+      ],
+      "size": [
+        210,
+        60
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 16,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "INT",
+          "type": "INT",
+          "links": [
+            1200
+          ]
+        }
+      ],
+      "title": "Get_total step",
+      "properties": {
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "total step"
+      ],
+      "color": "#1b4669",
+      "bgcolor": "#29699c"
+    },
+    {
+      "id": 288,
+      "type": "GetNode",
+      "pos": [
+        96.45500132624511,
+        -296.31747764826946
+      ],
+      "size": [
+        210,
+        60
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 17,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "INT",
+          "type": "INT",
+          "links": [
+            1202
+          ]
+        }
+      ],
+      "title": "Get_no lightning end step",
+      "properties": {
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "no lightning end step"
+      ],
+      "color": "#1b4669",
+      "bgcolor": "#29699c"
+    },
+    {
+      "id": 928,
+      "type": "GetNode",
+      "pos": [
+        83.82271484374995,
+        237.63467854704325
+      ],
+      "size": [
+        210,
+        60
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 18,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "INT",
+          "type": "INT",
+          "links": [
+            1188
+          ]
+        }
+      ],
+      "title": "Get_no lightning end step",
+      "properties": {
+        "Node name for S&R": "GetNode",
+        "aux_id": "kijai/ComfyUI-KJNodes",
+        "previousName": "no lightning end step",
+        "ue_properties": {
+          "version": "7.8",
+          "widget_ue_connectable": {},
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "no lightning end step"
+      ],
+      "color": "#223",
+      "bgcolor": "#335"
+    },
+    {
+      "id": 929,
+      "type": "GetNode",
+      "pos": [
+        82.8718320488589,
+        272.186589704068
+      ],
+      "size": [
+        220.6080078125,
+        60
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 19,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "INT",
+          "type": "INT",
+          "links": [
+            1190
+          ]
+        }
+      ],
+      "title": "Get_lightning high end step",
+      "properties": {
+        "Node name for S&R": "GetNode",
+        "aux_id": "kijai/ComfyUI-KJNodes",
+        "previousName": "lightning high end step",
+        "ue_properties": {
+          "version": "7.8",
+          "widget_ue_connectable": {},
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "lightning high end step"
+      ],
+      "color": "#223",
+      "bgcolor": "#335"
+    },
+    {
+      "id": 940,
+      "type": "GetNode",
+      "pos": [
+        83.69696646377247,
+        202.5203137602289
+      ],
+      "size": [
+        210,
+        60
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 20,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "CLIP",
+          "type": "CLIP",
+          "links": []
+        }
+      ],
+      "title": "Get_load clip",
+      "properties": {
+        "Node name for S&R": "GetNode",
+        "aux_id": "kijai/ComfyUI-KJNodes",
+        "previousName": "load clip",
+        "ue_properties": {
+          "version": "7.8",
+          "widget_ue_connectable": {},
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "load clip"
+      ],
+      "color": "#223",
+      "bgcolor": "#335"
+    },
+    {
+      "id": 927,
+      "type": "GetNode",
+      "pos": [
+        84.00512292507975,
+        163.52026680305386
+      ],
+      "size": [
+        210,
+        60
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 21,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "INT",
+          "type": "INT",
+          "links": [
+            1186
+          ]
+        }
+      ],
+      "title": "Get_total step",
+      "properties": {
+        "Node name for S&R": "GetNode",
+        "aux_id": "kijai/ComfyUI-KJNodes",
+        "previousName": "total step",
+        "ue_properties": {
+          "version": "7.8",
+          "widget_ue_connectable": {},
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "total step"
+      ],
+      "color": "#223",
+      "bgcolor": "#335"
+    },
+    {
+      "id": 926,
+      "type": "GetNode",
+      "pos": [
+        80.71426416760536,
+        127.27357232710855
+      ],
+      "size": [
+        220.45078125,
+        60
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 22,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": [
+            1195
+          ]
+        }
+      ],
+      "title": "Get_svi model lightning low",
+      "properties": {
+        "Node name for S&R": "GetNode",
+        "aux_id": "kijai/ComfyUI-KJNodes",
+        "previousName": "svi model lightning low",
+        "ue_properties": {
+          "version": "7.8",
+          "widget_ue_connectable": {},
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "svi model lightning low"
+      ],
+      "color": "#223",
+      "bgcolor": "#335"
+    },
+    {
+      "id": 925,
+      "type": "GetNode",
+      "pos": [
+        77.93599404312195,
+        93.81175955295063
+      ],
+      "size": [
+        225.9947265625,
+        60
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 23,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": [
+            1189
+          ]
+        }
+      ],
+      "title": "Get_svi model lightning high",
+      "properties": {
+        "Node name for S&R": "GetNode",
+        "aux_id": "kijai/ComfyUI-KJNodes",
+        "previousName": "svi model lightning high",
+        "ue_properties": {
+          "version": "7.8",
+          "widget_ue_connectable": {},
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "svi model lightning high"
+      ],
+      "color": "#223",
+      "bgcolor": "#335"
+    },
+    {
+      "id": 924,
+      "type": "GetNode",
+      "pos": [
+        75.71851553828922,
+        57.081819121884514
+      ],
+      "size": [
+        246.5982421875,
+        60
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 24,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": [
+            1185
+          ]
+        }
+      ],
+      "title": "Get_svi model no lightning high",
+      "properties": {
+        "Node name for S&R": "GetNode",
+        "aux_id": "kijai/ComfyUI-KJNodes",
+        "previousName": "svi model no lightning high",
+        "ue_properties": {
+          "version": "7.8",
+          "widget_ue_connectable": {},
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "svi model no lightning high"
+      ],
+      "color": "#223",
+      "bgcolor": "#335"
+    },
+    {
+      "id": 923,
+      "type": "GetNode",
+      "pos": [
+        75.94505480224906,
+        23.836637673558638
+      ],
+      "size": [
+        210,
+        60
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 25,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "VAE",
+          "type": "VAE",
+          "links": [
+            1196
+          ]
+        }
+      ],
+      "title": "Get_load vae",
+      "properties": {
+        "Node name for S&R": "GetNode",
+        "aux_id": "kijai/ComfyUI-KJNodes",
+        "previousName": "load vae",
+        "ue_properties": {
+          "version": "7.8",
+          "widget_ue_connectable": {},
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "load vae"
+      ],
+      "color": "#223",
+      "bgcolor": "#335"
+    },
+    {
+      "id": 921,
+      "type": "GetNode",
+      "pos": [
+        75.6068114394746,
+        -11.724644146950153
+      ],
+      "size": [
+        210,
+        60
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 26,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "LATENT",
+          "type": "LATENT",
+          "links": [
+            1193
+          ]
+        }
+      ],
+      "title": "Get_anchor sample",
+      "properties": {
+        "Node name for S&R": "GetNode",
+        "aux_id": "kijai/ComfyUI-KJNodes",
+        "previousName": "anchor sample",
+        "ue_properties": {
+          "version": "7.8",
+          "widget_ue_connectable": {},
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "anchor sample"
+      ],
+      "color": "#223",
+      "bgcolor": "#335"
+    },
+    {
+      "id": 290,
+      "type": "GetNode",
+      "pos": [
+        88.15382945124513,
+        -251.2592745232697
+      ],
+      "size": [
+        220.6080078125,
+        60
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 27,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "INT",
+          "type": "INT",
+          "links": [
+            1204
+          ]
+        }
+      ],
+      "title": "Get_lightning high end step",
+      "properties": {
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "lightning high end step"
+      ],
+      "color": "#1b4669",
+      "bgcolor": "#29699c"
+    },
+    {
+      "id": 120,
+      "type": "GetNode",
+      "pos": [
+        -2353.2474502307336,
+        -632.6135125300955
+      ],
+      "size": [
+        210,
+        60.92295998177042
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 28,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": [
+            1005
+          ]
+        }
+      ],
+      "title": "Get_model high",
+      "properties": {
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "model high"
+      ],
+      "color": "#223",
+      "bgcolor": "#335"
+    },
+    {
+      "id": 946,
+      "type": "GetNode",
+      "pos": [
+        89.64430528056525,
+        822.0343386789765
+      ],
+      "size": [
+        210,
+        60
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 29,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "INT",
+          "type": "INT",
+          "links": [
+            1175
+          ]
+        }
+      ],
+      "title": "Get_no lightning end step",
+      "properties": {
+        "Node name for S&R": "GetNode",
+        "aux_id": "kijai/ComfyUI-KJNodes",
+        "previousName": "no lightning end step",
+        "ue_properties": {
+          "version": "7.8",
+          "widget_ue_connectable": {},
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "no lightning end step"
+      ],
+      "color": "#223",
+      "bgcolor": "#335"
+    },
+    {
+      "id": 947,
+      "type": "GetNode",
+      "pos": [
+        89.31760073511063,
+        857.6202761789766
+      ],
+      "size": [
+        220.6080078125,
+        60
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 30,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "INT",
+          "type": "INT",
+          "links": [
+            1177
+          ]
+        }
+      ],
+      "title": "Get_lightning high end step",
+      "properties": {
+        "Node name for S&R": "GetNode",
+        "aux_id": "kijai/ComfyUI-KJNodes",
+        "previousName": "lightning high end step",
+        "ue_properties": {
+          "version": "7.8",
+          "widget_ue_connectable": {},
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "lightning high end step"
+      ],
+      "color": "#223",
+      "bgcolor": "#335"
+    },
+    {
+      "id": 948,
+      "type": "GetNode",
+      "pos": [
+        91.18194732601972,
+        895.8340545880668
+      ],
+      "size": [
+        232.7076171875,
+        60
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 31,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "FLOAT",
+          "type": "FLOAT",
+          "links": [
+            1174
+          ]
+        }
+      ],
+      "title": "Get_cfg ksampler nolightning",
+      "properties": {
+        "Node name for S&R": "GetNode",
+        "aux_id": "kijai/ComfyUI-KJNodes",
+        "previousName": "cfg ksampler nolightning",
+        "ue_properties": {
+          "version": "7.8",
+          "widget_ue_connectable": {},
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "cfg ksampler nolightning"
+      ],
+      "color": "#223",
+      "bgcolor": "#335"
+    },
+    {
+      "id": 945,
+      "type": "GetNode",
+      "pos": [
+        90.62993129150277,
+        783.4515979050909
+      ],
+      "size": [
+        210,
+        60
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 32,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "INT",
+          "type": "INT",
+          "links": [
+            1173
+          ]
+        }
+      ],
+      "title": "Get_total step",
+      "properties": {
+        "Node name for S&R": "GetNode",
+        "aux_id": "kijai/ComfyUI-KJNodes",
+        "previousName": "total step",
+        "ue_properties": {
+          "version": "7.8",
+          "widget_ue_connectable": {},
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "total step"
+      ],
+      "color": "#223",
+      "bgcolor": "#335"
+    },
+    {
+      "id": 944,
+      "type": "GetNode",
+      "pos": [
+        89.00028519919343,
+        736.0196906598709
+      ],
+      "size": [
+        220.45078125,
+        60
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 33,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": [
+            1183
+          ]
+        }
+      ],
+      "title": "Get_svi model lightning low",
+      "properties": {
+        "Node name for S&R": "GetNode",
+        "aux_id": "kijai/ComfyUI-KJNodes",
+        "previousName": "svi model lightning low",
+        "ue_properties": {
+          "version": "7.8",
+          "widget_ue_connectable": {},
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "svi model lightning low"
+      ],
+      "color": "#223",
+      "bgcolor": "#335"
+    },
+    {
+      "id": 943,
+      "type": "GetNode",
+      "pos": [
+        88.49093567637146,
+        698.1999627475948
+      ],
+      "size": [
+        225.9947265625,
+        60
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 34,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": [
+            1176
+          ]
+        }
+      ],
+      "title": "Get_svi model lightning high",
+      "properties": {
+        "Node name for S&R": "GetNode",
+        "aux_id": "kijai/ComfyUI-KJNodes",
+        "previousName": "svi model lightning high",
+        "ue_properties": {
+          "version": "7.8",
+          "widget_ue_connectable": {},
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "svi model lightning high"
+      ],
+      "color": "#223",
+      "bgcolor": "#335"
+    },
+    {
+      "id": 942,
+      "type": "GetNode",
+      "pos": [
+        86.01695227980761,
+        659.62348697284
+      ],
+      "size": [
+        246.5982421875,
+        60
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 35,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": [
+            1172
+          ]
+        }
+      ],
+      "title": "Get_svi model no lightning high",
+      "properties": {
+        "Node name for S&R": "GetNode",
+        "aux_id": "kijai/ComfyUI-KJNodes",
+        "previousName": "svi model no lightning high",
+        "ue_properties": {
+          "version": "7.8",
+          "widget_ue_connectable": {},
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "svi model no lightning high"
+      ],
+      "color": "#223",
+      "bgcolor": "#335"
+    },
+    {
+      "id": 941,
+      "type": "GetNode",
+      "pos": [
+        83.79595236169163,
+        622.5720608790781
+      ],
+      "size": [
+        210,
+        60
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 36,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "VAE",
+          "type": "VAE",
+          "links": [
+            1178
+          ]
+        }
+      ],
+      "title": "Get_load vae",
+      "properties": {
+        "Node name for S&R": "GetNode",
+        "aux_id": "kijai/ComfyUI-KJNodes",
+        "previousName": "load vae",
+        "ue_properties": {
+          "version": "7.8",
+          "widget_ue_connectable": {},
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "load vae"
+      ],
+      "color": "#223",
+      "bgcolor": "#335"
+    },
+    {
+      "id": 939,
+      "type": "GetNode",
+      "pos": [
+        83.42663417987347,
+        580.3640139933952
+      ],
+      "size": [
+        210,
+        60
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 37,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "LATENT",
+          "type": "LATENT",
+          "links": [
+            1181
+          ]
+        }
+      ],
+      "title": "Get_anchor sample",
+      "properties": {
+        "Node name for S&R": "GetNode",
+        "aux_id": "kijai/ComfyUI-KJNodes",
+        "previousName": "anchor sample",
+        "ue_properties": {
+          "version": "7.8",
+          "widget_ue_connectable": {},
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "anchor sample"
+      ],
+      "color": "#223",
+      "bgcolor": "#335"
+    },
+    {
+      "id": 891,
+      "type": "CLIPTextEncode",
+      "pos": [
+        -938.0168763572229,
+        117.88321851008072
+      ],
+      "size": [
+        274.03007651084715,
+        125.89909188076172
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 89,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": 1015
+        },
+        {
+          "name": "text",
+          "type": "STRING",
+          "widget": {
+            "name": "text"
+          },
+          "link": 1160
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "slot_index": 0,
+          "links": [
+            1162
+          ]
+        }
+      ],
+      "title": "Positive Prompt",
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.3.45",
+        "Node name for S&R": "CLIPTextEncode",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "She drops her towel, she squeezes her breasts with both hands and moans, her finger are feminine and delicate with bright red nails"
+      ],
+      "color": "#232",
+      "bgcolor": "#353"
+    },
+    {
+      "id": 952,
+      "type": "SetNode",
+      "pos": [
+        -732.2171517850412,
+        116.60840393808735
+      ],
+      "size": [
+        210,
+        60
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 104,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "link": 1162
+        }
+      ],
+      "outputs": [
+        {
+          "name": "*",
+          "type": "*",
+          "links": null
+        }
+      ],
+      "title": "Set_pos_prompt",
+      "properties": {
+        "previousName": "pos_prompt",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "pos_prompt"
+      ],
+      "color": "#2a363b",
+      "bgcolor": "#3f5159"
+    },
+    {
+      "id": 892,
+      "type": "CLIPTextEncode",
+      "pos": [
+        -936.2288839738903,
+        523.9385246975424
+      ],
+      "size": [
+        327.2152585843121,
+        124.36420402003517
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 90,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": 1016
+        },
+        {
+          "name": "text",
+          "type": "STRING",
+          "widget": {
+            "name": "text"
+          },
+          "link": 1161
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "slot_index": 0,
+          "links": [
+            1163
+          ]
+        }
+      ],
+      "title": "Negative Prompt",
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.3.45",
+        "Node name for S&R": "CLIPTextEncode",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "色调艳丽，过曝，静态，细节模糊不清，字幕，风格，作品，画作，画面，静止，整体发灰，最差质量，低质量，JPEG压缩残留，丑陋的，残缺的，多余的手指，画得不好的手部，画得不好的脸部，畸形的，毁容的，形态畸形的肢体，手指融合，静止不动的画面，杂乱的背景，三条腿，背景人很多，倒着走"
+      ],
+      "color": "#322",
+      "bgcolor": "#533"
+    },
+    {
+      "id": 953,
+      "type": "SetNode",
+      "pos": [
+        -725.6948747942715,
+        523.9521075945571
+      ],
+      "size": [
+        210,
+        60
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 105,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "link": 1163
+        }
+      ],
+      "outputs": [
+        {
+          "name": "*",
+          "type": "*",
+          "links": null
+        }
+      ],
+      "title": "Set_neg_prompt",
+      "properties": {
+        "previousName": "neg_prompt",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "neg_prompt"
+      ],
+      "color": "#2a363b",
+      "bgcolor": "#3f5159"
+    },
+    {
+      "id": 959,
+      "type": "GetNode",
+      "pos": [
+        103.02681857230226,
+        989.4272343068376
+      ],
+      "size": [
+        210,
+        34
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 38,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": [
+            1180
+          ]
+        }
+      ],
+      "title": "Get_neg_prompt",
+      "properties": {
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "neg_prompt"
+      ],
+      "color": "#2a363b",
+      "bgcolor": "#3f5159"
+    },
+    {
+      "id": 960,
+      "type": "GetNode",
+      "pos": [
+        95.11385076574,
+        -164.14561565566274
+      ],
+      "size": [
+        210,
+        34
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 39,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": [
+            1208
+          ]
+        }
+      ],
+      "title": "Get_neg_prompt",
+      "properties": {
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "neg_prompt"
+      ],
+      "color": "#2a363b",
+      "bgcolor": "#3f5159"
+    },
+    {
+      "id": 931,
+      "type": "ImageBatchExtendWithOverlap",
+      "pos": [
+        843.3329293773658,
+        -120.7200457791672
+      ],
+      "size": [
+        321.6236328125,
+        146
+      ],
+      "flags": {},
+      "order": 117,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "source_images",
+          "type": "IMAGE",
+          "link": 1127
+        },
+        {
+          "name": "new_images",
+          "shape": 7,
+          "type": "IMAGE",
+          "link": 1198
+        }
+      ],
+      "outputs": [
+        {
+          "name": "source_images",
+          "type": "IMAGE",
+          "links": []
+        },
+        {
+          "name": "start_images",
+          "type": "IMAGE",
+          "links": []
+        },
+        {
+          "name": "extended_images",
+          "type": "IMAGE",
+          "links": [
+            1157
+          ]
+        }
+      ],
+      "title": "Merge Pass 3 (chain)",
+      "properties": {
+        "cnr_id": "comfyui-kjnodes",
+        "ver": "79f529a84a8c20fe5dcdfa984c6be7a94102c014",
+        "Node name for S&R": "ImageBatchExtendWithOverlap",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        },
+        "aux_id": "kijai/ComfyUI-KJNodes"
+      },
+      "widgets_values": [
+        5,
+        "source",
+        "linear_blend"
+      ]
+    },
+    {
+      "id": 930,
+      "type": "GetNode",
+      "pos": [
+        84.69498046874996,
+        307.0190535470432
+      ],
+      "size": [
+        232.7076171875,
+        60
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 40,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "FLOAT",
+          "type": "FLOAT",
+          "links": [
+            1187
+          ]
+        }
+      ],
+      "title": "Get_cfg ksampler nolightning",
+      "properties": {
+        "Node name for S&R": "GetNode",
+        "aux_id": "kijai/ComfyUI-KJNodes",
+        "previousName": "cfg ksampler nolightning",
+        "ue_properties": {
+          "version": "7.8",
+          "widget_ue_connectable": {},
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "cfg ksampler nolightning"
+      ],
+      "color": "#223",
+      "bgcolor": "#335"
+    },
+    {
+      "id": 958,
+      "type": "GetNode",
+      "pos": [
+        91.81995232823972,
+        395.1276655943374
+      ],
+      "size": [
+        210,
+        60
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 41,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": [
+            1192
+          ]
+        }
+      ],
+      "title": "Get_neg_prompt",
+      "properties": {
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "neg_prompt"
+      ],
+      "color": "#2a363b",
+      "bgcolor": "#3f5159"
+    },
+    {
+      "id": 968,
+      "type": "GetNode",
+      "pos": [
+        97.14087842577091,
+        -119.07843987736742
+      ],
+      "size": [
+        210,
+        60
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 42,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "INT",
+          "type": "INT",
+          "links": [
+            1231
+          ]
+        }
+      ],
+      "title": "Get_seg_length",
+      "properties": {
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "seg_length"
+      ],
+      "color": "#2a363b",
+      "bgcolor": "#3f5159"
+    },
+    {
+      "id": 285,
+      "type": "GetNode",
+      "pos": [
+        81.01348949451348,
+        -697.7577328123882
+      ],
+      "size": [
+        265.91695237214697,
+        58
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 43,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "INT",
+          "type": "INT",
+          "links": [
+            1218
+          ]
+        }
+      ],
+      "title": "Get_lightning high end step",
+      "properties": {
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "lightning high end step"
+      ],
+      "color": "#1b4669",
+      "bgcolor": "#29699c"
+    },
+    {
+      "id": 278,
+      "type": "GetNode",
+      "pos": [
+        83.96853064073818,
+        -739.3807154147543
+      ],
+      "size": [
+        210,
+        60
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 44,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "INT",
+          "type": "INT",
+          "links": [
+            1216
+          ]
+        }
+      ],
+      "title": "Get_no lightning end step",
+      "properties": {
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "no lightning end step"
+      ],
+      "color": "#1b4669",
+      "bgcolor": "#29699c"
+    },
+    {
+      "id": 282,
+      "type": "GetNode",
+      "pos": [
+        87.63380815764275,
+        -782.0408112073917
+      ],
+      "size": [
+        210,
+        60
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 45,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "INT",
+          "type": "INT",
+          "links": [
+            1214
+          ]
+        }
+      ],
+      "title": "Get_total step",
+      "properties": {
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "total step"
+      ],
+      "color": "#1b4669",
+      "bgcolor": "#29699c"
+    },
+    {
+      "id": 955,
+      "type": "GetNode",
+      "pos": [
+        86.31586288069086,
+        -655.0482429096068
+      ],
+      "size": [
+        210,
+        58
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 46,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": [
+            1221
+          ]
+        }
+      ],
+      "title": "Get_pos_prompt",
+      "properties": {
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "pos_prompt"
+      ],
+      "color": "#2a363b",
+      "bgcolor": "#3f5159"
+    },
+    {
+      "id": 961,
+      "type": "GetNode",
+      "pos": [
+        87.59390423822286,
+        -610.7316206566015
+      ],
+      "size": [
+        210,
+        34
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 47,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": [
+            1222
+          ]
+        }
+      ],
+      "title": "Get_neg_prompt",
+      "properties": {
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "neg_prompt"
+      ],
+      "color": "#2a363b",
+      "bgcolor": "#3f5159"
+    },
+    {
+      "id": 969,
+      "type": "GetNode",
+      "pos": [
+        91.65944998850529,
+        -568.4596617030624
+      ],
+      "size": [
+        210,
+        34
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 48,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "INT",
+          "type": "INT",
+          "links": [
+            1232
+          ]
+        }
+      ],
+      "title": "Get_seg_length",
+      "properties": {
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "seg_length"
+      ],
+      "color": "#2a363b",
+      "bgcolor": "#3f5159"
+    },
+    {
+      "id": 970,
+      "type": "GetNode",
+      "pos": [
+        93.03001253546232,
+        435.6901786425425
+      ],
+      "size": [
+        210,
+        34
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 49,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "INT",
+          "type": "INT",
+          "links": [
+            1233
+          ]
+        }
+      ],
+      "title": "Get_seg_length",
+      "properties": {
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "seg_length"
+      ],
+      "color": "#2a363b",
+      "bgcolor": "#3f5159"
+    },
+    {
+      "id": 971,
+      "type": "GetNode",
+      "pos": [
+        104.62256512749823,
+        1033.6134975756752
+      ],
+      "size": [
+        210,
+        34
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 50,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "INT",
+          "type": "INT",
+          "links": [
+            1234
+          ]
+        }
+      ],
+      "title": "Get_seg_length",
+      "properties": {
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "seg_length"
+      ],
+      "color": "#2a363b",
+      "bgcolor": "#3f5159"
+    },
+    {
+      "id": 977,
+      "type": "1cde9493-dec3-474f-894d-42eedd890bdd",
+      "pos": [
+        1264.6765490550918,
+        -74.83984288541598
+      ],
+      "size": [
+        212.5999999999999,
+        26
+      ],
+      "flags": {},
+      "order": 119,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "image",
+          "type": "IMAGE",
+          "link": 1243
+        }
+      ],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": [
+            1244
+          ]
+        }
+      ],
+      "properties": {
+        "proxyWidgets": [],
+        "cnr_id": "comfy-core",
+        "ver": "0.22.0",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "input_ue_unconnectable": {},
+          "version": "7.8"
+        }
+      },
+      "widgets_values": [],
+      "color": "#322",
+      "bgcolor": "#533"
+    },
+    {
+      "id": 325,
+      "type": "Power Lora Loader (rgthree)",
+      "pos": [
+        -1402.0781249999989,
+        -600.2195312500005
+      ],
+      "size": [
+        340.519921875,
+        142
+      ],
+      "flags": {},
+      "order": 76,
+      "mode": 0,
+      "inputs": [
+        {
+          "dir": 3,
+          "name": "model",
+          "type": "MODEL",
+          "link": 1030
+        },
+        {
+          "dir": 3,
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "dir": 4,
+          "name": "MODEL",
+          "shape": 3,
+          "type": "MODEL",
+          "links": [
+            1094
+          ]
+        },
+        {
+          "dir": 4,
+          "name": "CLIP",
+          "shape": 3,
+          "type": "CLIP",
+          "links": null
+        }
+      ],
+      "title": "High LoRAs 1",
+      "properties": {
+        "cnr_id": "rgthree-comfy",
+        "ver": "50fcbbf580696025e84b111fde75b7580f56979f",
+        "Show Strengths": "Single Strength",
+        "Match": "",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        {},
+        {
+          "type": "PowerLoraLoaderHeaderWidget"
+        },
+        {},
+        ""
+      ]
+    },
+    {
+      "id": 275,
+      "type": "Power Lora Loader (rgthree)",
+      "pos": [
+        -1411.9222656249988,
+        -391.29648437500003
+      ],
+      "size": [
+        357.1814197451862,
+        140.36492009173446
+      ],
+      "flags": {},
+      "order": 77,
+      "mode": 0,
+      "inputs": [
+        {
+          "dir": 3,
+          "name": "model",
+          "type": "MODEL",
+          "link": 1031
+        },
+        {
+          "dir": 3,
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "dir": 4,
+          "name": "MODEL",
+          "shape": 3,
+          "type": "MODEL",
+          "links": [
+            1095
+          ]
+        },
+        {
+          "dir": 4,
+          "name": "CLIP",
+          "shape": 3,
+          "type": "CLIP",
+          "links": null
+        }
+      ],
+      "title": "High LoRAs 2",
+      "properties": {
+        "cnr_id": "rgthree-comfy",
+        "ver": "50fcbbf580696025e84b111fde75b7580f56979f",
+        "Show Strengths": "Single Strength",
+        "Match": "",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        {},
+        {
+          "type": "PowerLoraLoaderHeaderWidget"
+        },
+        {},
+        ""
+      ]
+    },
+    {
+      "id": 276,
+      "type": "Power Lora Loader (rgthree)",
+      "pos": [
+        -1420.0175781249989,
+        -181.16171874999992
+      ],
+      "size": [
+        368.2111505587619,
+        133.995640633613
+      ],
+      "flags": {},
+      "order": 78,
+      "mode": 0,
+      "inputs": [
+        {
+          "dir": 3,
+          "name": "model",
+          "type": "MODEL",
+          "link": 1033
+        },
+        {
+          "dir": 3,
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "dir": 4,
+          "name": "MODEL",
+          "shape": 3,
+          "type": "MODEL",
+          "links": [
+            1096
+          ]
+        },
+        {
+          "dir": 4,
+          "name": "CLIP",
+          "shape": 3,
+          "type": "CLIP",
+          "links": null
+        }
+      ],
+      "title": "Low LoRAs",
+      "properties": {
+        "cnr_id": "rgthree-comfy",
+        "ver": "50fcbbf580696025e84b111fde75b7580f56979f",
+        "Show Strengths": "Single Strength",
+        "Match": "",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        {},
+        {
+          "type": "PowerLoraLoaderHeaderWidget"
+        },
+        {},
+        ""
+      ]
+    },
+    {
+      "id": 949,
+      "type": "ImageBatchExtendWithOverlap",
+      "pos": [
+        849.4225053956453,
+        386.88364411747295
+      ],
+      "size": [
+        321.6236328125,
+        146
+      ],
+      "flags": {},
+      "order": 118,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "source_images",
+          "type": "IMAGE",
+          "link": 1157
+        },
+        {
+          "name": "new_images",
+          "shape": 7,
+          "type": "IMAGE",
+          "link": 1184
+        }
+      ],
+      "outputs": [
+        {
+          "name": "source_images",
+          "type": "IMAGE",
+          "links": []
+        },
+        {
+          "name": "start_images",
+          "type": "IMAGE",
+          "links": []
+        },
+        {
+          "name": "extended_images",
+          "type": "IMAGE",
+          "links": [
+            1243
+          ]
+        }
+      ],
+      "title": "Merge Pass 4 (chain)",
+      "properties": {
+        "cnr_id": "comfyui-kjnodes",
+        "ver": "79f529a84a8c20fe5dcdfa984c6be7a94102c014",
+        "Node name for S&R": "ImageBatchExtendWithOverlap",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        },
+        "aux_id": "kijai/ComfyUI-KJNodes"
+      },
+      "widgets_values": [
+        5,
+        "source",
+        "linear_blend"
+      ]
+    },
+    {
+      "id": 986,
+      "type": "GetNode",
+      "pos": [
+        97.64272035706128,
+        -62.78485295555387
+      ],
+      "size": [
+        210,
+        60
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 51,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "INT",
+          "type": "INT",
+          "links": [
+            1264,
+            1265
+          ]
+        }
+      ],
+      "title": "Get_seed",
+      "properties": {
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "seed"
+      ]
+    },
+    {
+      "id": 987,
+      "type": "GetNode",
+      "pos": [
+        100.71912660706053,
+        -523.3727826430538
+      ],
+      "size": [
+        210,
+        34
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 52,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "INT",
+          "type": "INT",
+          "links": [
+            1266
+          ]
+        }
+      ],
+      "title": "Get_seed",
+      "properties": {
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "seed"
+      ]
+    },
+    {
+      "id": 988,
+      "type": "GetNode",
+      "pos": [
+        111.51459535706013,
+        1077.5092095444463
+      ],
+      "size": [
+        210,
+        34
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 53,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "INT",
+          "type": "INT",
+          "links": [
+            1267
+          ]
+        }
+      ],
+      "title": "Get_seed",
+      "properties": {
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "seed"
+      ]
+    },
+    {
+      "id": 224,
+      "type": "CLIPLoader",
+      "pos": [
+        -2986.906328125001,
+        -303.23382812500006
+      ],
+      "size": [
+        346.391845703125,
+        106
+      ],
+      "flags": {},
+      "order": 54,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "CLIP",
+          "type": "CLIP",
+          "slot_index": 0,
+          "links": [
+            1003
+          ]
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.3.45",
+        "Node name for S&R": "CLIPLoader",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        },
+        "models": [
+          {
+            "name": "umt5_xxl_fp8_e4m3fn_scaled.safetensors",
+            "url": "https://huggingface.co/Comfy-Org/Wan_2.1_ComfyUI_repackaged/resolve/main/split_files/text_encoders/umt5_xxl_fp8_e4m3fn_scaled.safetensors",
+            "directory": "text_encoders"
+          }
+        ]
+      },
+      "widgets_values": [
+        "umt5_xxl_fp8_e4m3fn_scaled.safetensors",
+        "wan",
+        "default"
+      ],
+      "color": "#223",
+      "bgcolor": "#335"
+    },
+    {
+      "id": 906,
+      "type": "ImageBatchExtendWithOverlap",
+      "pos": [
+        841.0034650655774,
+        -635.9592554040113
+      ],
+      "size": [
+        321.6236328125,
+        146
+      ],
+      "flags": {},
+      "order": 112,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "source_images",
+          "type": "IMAGE",
+          "link": 1224
+        },
+        {
+          "name": "new_images",
+          "shape": 7,
+          "type": "IMAGE",
+          "link": 1211
+        }
+      ],
+      "outputs": [
+        {
+          "name": "source_images",
+          "type": "IMAGE",
+          "links": []
+        },
+        {
+          "name": "start_images",
+          "type": "IMAGE",
+          "links": []
+        },
+        {
+          "name": "extended_images",
+          "type": "IMAGE",
+          "links": [
+            1127,
+            1270
+          ]
+        }
+      ],
+      "title": "Merge Pass 1 + Pass 2 overlap",
+      "properties": {
+        "cnr_id": "comfyui-kjnodes",
+        "ver": "79f529a84a8c20fe5dcdfa984c6be7a94102c014",
+        "Node name for S&R": "ImageBatchExtendWithOverlap",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        },
+        "aux_id": "kijai/ComfyUI-KJNodes"
+      },
+      "widgets_values": [
+        5,
+        "source",
+        "linear_blend"
+      ]
+    },
+    {
+      "id": 357,
+      "type": "SetNode",
+      "pos": [
+        -2312.934675232438,
+        45.9272824121901
+      ],
+      "size": [
+        241.6080078125,
+        34
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 109,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "link": 1012
+        }
+      ],
+      "outputs": [
+        {
+          "name": "*",
+          "type": "*",
+          "links": null
+        }
+      ],
+      "title": "Set_lora svi lightning low",
+      "properties": {
+        "previousName": "lora svi lightning low",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "lora svi lightning low"
+      ],
+      "color": "#223",
+      "bgcolor": "#335"
+    },
+    {
+      "id": 195,
+      "type": "INTConstant",
+      "pos": [
+        -667.6115973840508,
+        -633.0020198149457
+      ],
+      "size": [
+        284.8243657221292,
+        58
+      ],
+      "flags": {
+        "collapsed": false
+      },
+      "order": 55,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "value",
+          "type": "INT",
+          "links": [
+            1027
+          ]
+        }
+      ],
+      "title": "total step",
+      "properties": {
+        "cnr_id": "comfyui-kjnodes",
+        "ver": "487c7d86a0230aae3d8c0a37d517159b73834f85",
+        "Node name for S&R": "INTConstant",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        8
+      ],
+      "color": "#1b4669",
+      "bgcolor": "#29699c"
+    },
+    {
+      "id": 966,
+      "type": "INTConstant",
+      "pos": [
+        -939.2259130198054,
+        -634.4151759604352
+      ],
+      "size": [
+        252.7926605935387,
+        58
+      ],
+      "flags": {
+        "collapsed": false
+      },
+      "order": 56,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "value",
+          "type": "INT",
+          "links": [
+            1230
+          ]
+        }
+      ],
+      "title": "Segment Length (in frames)",
+      "properties": {
+        "cnr_id": "comfyui-kjnodes",
+        "ver": "487c7d86a0230aae3d8c0a37d517159b73834f85",
+        "Node name for S&R": "INTConstant",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        65
+      ],
+      "color": "#1b4669",
+      "bgcolor": "#29699c"
+    },
+    {
+      "id": 512,
+      "type": "VHS_VideoCombine",
+      "pos": [
+        2242.3559359898654,
+        -352.08130886418303
+      ],
+      "size": [
+        647.1444197150872,
+        1253.8752729217927
+      ],
+      "flags": {},
+      "order": 120,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "link": 1244
+        },
+        {
+          "name": "audio",
+          "shape": 7,
+          "type": "AUDIO",
+          "link": null
+        },
+        {
+          "name": "meta_batch",
+          "shape": 7,
+          "type": "VHS_BatchManager",
+          "link": null
+        },
+        {
+          "name": "vae",
+          "shape": 7,
+          "type": "VAE",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "Filenames",
+          "type": "VHS_FILENAMES",
+          "links": null
+        }
+      ],
+      "title": "Final Video",
+      "properties": {
+        "cnr_id": "comfyui-videohelpersuite",
+        "ver": "8550981384301e9bc5bfea83e5c2c75258102593",
+        "Node name for S&R": "VHS_VideoCombine",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": {
+        "frame_rate": 32,
+        "loop_count": 0,
+        "filename_prefix": "Wan2.2_SVI_4pass_MoreMotion",
+        "format": "video/h264-mp4",
+        "pix_fmt": "yuv420p",
+        "crf": 19,
+        "save_metadata": true,
+        "trim_to_audio": false,
+        "pingpong": false,
+        "save_output": true,
+        "videopreview": {
+          "hidden": false,
+          "paused": false,
+          "params": {
+            "filename": "Wan2.2_SVI_4pass_MoreMotion_00032.mp4",
+            "subfolder": "",
+            "type": "output",
+            "format": "video/h264-mp4",
+            "frame_rate": 32,
+            "workflow": "Wan2.2_SVI_4pass_MoreMotion_00032.png",
+            "fullpath": "/ComfyUI/output/Wan2.2_SVI_4pass_MoreMotion_00032.mp4"
+          }
+        }
+      }
+    },
+    {
+      "id": 896,
+      "type": "VAEEncode",
+      "pos": [
+        -195.48306324342607,
+        -862.4309533305707
+      ],
+      "size": [
+        191.30234375,
+        46
+      ],
+      "flags": {
+        "collapsed": false
+      },
+      "order": 73,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "pixels",
+          "type": "IMAGE",
+          "link": 1021
+        },
+        {
+          "name": "vae",
+          "type": "VAE",
+          "link": 1022
+        }
+      ],
+      "outputs": [
+        {
+          "name": "LATENT",
+          "type": "LATENT",
+          "links": [
+            1023
+          ]
+        }
+      ],
+      "title": "Encode anchor sample",
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.5.1",
+        "Node name for S&R": "VAEEncode",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.0.1",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [],
+      "color": "#322",
+      "bgcolor": "#533"
+    },
+    {
+      "id": 62,
+      "type": "LoadImage",
+      "pos": [
+        -925.698024180926,
+        -1009.7825939555703
+      ],
+      "size": [
+        315,
+        314.0000305175781
+      ],
+      "flags": {},
+      "order": 57,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "slot_index": 0,
+          "links": [
+            1013
+          ]
+        },
+        {
+          "name": "MASK",
+          "type": "MASK",
+          "slot_index": 1,
+          "links": null
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.3.45",
+        "Node name for S&R": "LoadImage",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "973P98PFPYK9DJ1XBJB1XCKR20.jpeg",
+        "image"
+      ],
+      "color": "#232",
+      "bgcolor": "#353"
+    },
+    {
+      "id": 989,
+      "type": "VHS_VideoCombine",
+      "pos": [
+        1559.0669195989299,
+        -347.92576399785435
+      ],
+      "size": [
+        647.1444197150872,
+        1253.8752729217927
+      ],
+      "flags": {},
+      "order": 115,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "link": 1270
+        },
+        {
+          "name": "audio",
+          "shape": 7,
+          "type": "AUDIO",
+          "link": null
+        },
+        {
+          "name": "meta_batch",
+          "shape": 7,
+          "type": "VHS_BatchManager",
+          "link": null
+        },
+        {
+          "name": "vae",
+          "shape": 7,
+          "type": "VAE",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "Filenames",
+          "type": "VHS_FILENAMES",
+          "links": null
+        }
+      ],
+      "title": "Final Video",
+      "properties": {
+        "cnr_id": "comfyui-videohelpersuite",
+        "ver": "8550981384301e9bc5bfea83e5c2c75258102593",
+        "Node name for S&R": "VHS_VideoCombine",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": {
+        "frame_rate": 16,
+        "loop_count": 0,
+        "filename_prefix": "Wan2.2_SVI_4pass_MoreMotion",
+        "format": "video/h264-mp4",
+        "pix_fmt": "yuv420p",
+        "crf": 19,
+        "save_metadata": true,
+        "trim_to_audio": false,
+        "pingpong": false,
+        "save_output": true,
+        "videopreview": {
+          "hidden": false,
+          "paused": false,
+          "params": {
+            "filename": "Wan2.2_SVI_4pass_MoreMotion_00031.mp4",
+            "subfolder": "",
+            "type": "output",
+            "format": "video/h264-mp4",
+            "frame_rate": 16,
+            "workflow": "Wan2.2_SVI_4pass_MoreMotion_00031.png",
+            "fullpath": "/ComfyUI/output/Wan2.2_SVI_4pass_MoreMotion_00031.mp4"
+          }
+        }
+      }
+    },
+    {
+      "id": 967,
+      "type": "SetNode",
+      "pos": [
+        -896.4494964979231,
+        -529.1531514018326
+      ],
+      "size": [
+        210,
+        60
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 83,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "INT",
+          "type": "INT",
+          "link": 1230
+        }
+      ],
+      "outputs": [
+        {
+          "name": "*",
+          "type": "*",
+          "links": null
+        }
+      ],
+      "title": "Set_seg_length",
+      "properties": {
+        "previousName": "seg_length",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "seg_length"
+      ],
+      "color": "#2a363b",
+      "bgcolor": "#3f5159"
+    },
+    {
+      "id": 280,
+      "type": "SetNode",
+      "pos": [
+        -652.373159884051,
+        -524.6454573149452
+      ],
+      "size": [
+        210,
+        60
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 82,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "INT",
+          "type": "INT",
+          "link": 1027
+        }
+      ],
+      "outputs": [
+        {
+          "name": "*",
+          "type": "*",
+          "links": null
+        }
+      ],
+      "title": "Set_total step",
+      "properties": {
+        "previousName": "total step",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "total step"
+      ],
+      "color": "#1b4669",
+      "bgcolor": "#29699c"
+    },
+    {
+      "id": 193,
+      "type": "INTConstant",
+      "pos": [
+        -348.7274495715511,
+        -625.0505331743203
+      ],
+      "size": [
+        299.3425262353958,
+        58
+      ],
+      "flags": {},
+      "order": 58,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "value",
+          "type": "INT",
+          "links": [
+            1028
+          ]
+        }
+      ],
+      "title": "no lightning end step",
+      "properties": {
+        "cnr_id": "comfyui-kjnodes",
+        "ver": "487c7d86a0230aae3d8c0a37d517159b73834f85",
+        "Node name for S&R": "INTConstant",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        1
+      ],
+      "color": "#1b4669",
+      "bgcolor": "#29699c"
+    },
+    {
+      "id": 984,
+      "type": "Seed (rgthree)",
+      "pos": [
+        -925.5986858929385,
+        -467.50432951805374
+      ],
+      "size": [
+        216.74894531250004,
+        130
+      ],
+      "flags": {},
+      "order": 59,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "dir": 4,
+          "name": "SEED",
+          "shape": 3,
+          "type": "INT",
+          "links": [
+            1263
+          ]
+        }
+      ],
+      "properties": {
+        "cnr_id": "rgthree-comfy",
+        "ver": "738105af5fb14e96fbecaf406dc356e284797e8c",
+        "randomMax": 1125899906842624,
+        "randomMin": 0,
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "input_ue_unconnectable": {},
+          "version": "7.8"
+        }
+      },
+      "widgets_values": [
+        -1,
+        "",
+        "",
+        "okay"
+      ]
+    },
+    {
+      "id": 985,
+      "type": "SetNode",
+      "pos": [
+        -884.1541155804385,
+        -295.87811858055375
+      ],
+      "size": [
+        210,
+        60
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 86,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "INT",
+          "type": "INT",
+          "link": 1263
+        }
+      ],
+      "outputs": [
+        {
+          "name": "*",
+          "type": "*",
+          "links": null
+        }
+      ],
+      "title": "Set_seed",
+      "properties": {
+        "previousName": "seed",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "seed"
+      ]
+    },
+    {
+      "id": 194,
+      "type": "INTConstant",
+      "pos": [
+        -663.912790782488,
+        -457.473610869632
+      ],
+      "size": [
+        278.34404059827216,
+        58
+      ],
+      "flags": {
+        "collapsed": false
+      },
+      "order": 60,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "value",
+          "type": "INT",
+          "links": [
+            1029
+          ]
+        }
+      ],
+      "title": "lightning high end step",
+      "properties": {
+        "cnr_id": "comfyui-kjnodes",
+        "ver": "487c7d86a0230aae3d8c0a37d517159b73834f85",
+        "Node name for S&R": "INTConstant",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        4
+      ],
+      "color": "#1b4669",
+      "bgcolor": "#29699c"
+    },
+    {
+      "id": 314,
+      "type": "FloatConstant",
+      "pos": [
+        -343.912081719989,
+        -454.84178997119545
+      ],
+      "size": [
+        269.1158203125,
+        60.708392407523206
+      ],
+      "flags": {
+        "collapsed": false
+      },
+      "order": 61,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "label": "值",
+          "name": "value",
+          "type": "FLOAT",
+          "links": [
+            1026
+          ]
+        }
+      ],
+      "title": "cfg first ksampler without lightning",
+      "properties": {
+        "cnr_id": "comfyui-kjnodes",
+        "ver": "1.1.9",
+        "Node name for S&R": "FloatConstant",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "input_ue_unconnectable": {},
+          "version": "7.4.1"
+        }
+      },
+      "widgets_values": [
+        4
+      ],
+      "color": "#232",
+      "bgcolor": "#353"
+    },
+    {
+      "id": 951,
+      "type": "PrimitiveStringMultiline",
+      "pos": [
+        -829.1250189527979,
+        489.15145195499997
+      ],
+      "size": [
+        400,
+        200.33897210743794
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 62,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "STRING",
+          "type": "STRING",
+          "links": [
+            1161
+          ]
+        }
+      ],
+      "title": "Negative Prompt",
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.22.0",
+        "Node name for S&R": "PrimitiveStringMultiline",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "input_ue_unconnectable": {},
+          "version": "7.8"
+        }
+      },
+      "widgets_values": [
+        "色调艳丽，过曝，静态，细节模糊不清，字幕，风格，作品，画作，画面，静止，整体发灰，最差质量，低质量，JPEG压缩残留，丑陋的，残缺的，多余的手指，画得不好的手部，画得不好的脸部，畸形的，毁容的，形态畸形的肢体，手指融合，静止不动的画面，杂乱的背景，三条腿，背景人很多，倒着走"
+      ],
+      "color": "#322",
+      "bgcolor": "#533"
+    },
+    {
+      "id": 950,
+      "type": "PrimitiveStringMultiline",
+      "pos": [
+        -947.9839809430988,
+        -134.0167219658383
+      ],
+      "size": [
+        400,
+        200
+      ],
+      "flags": {},
+      "order": 63,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "STRING",
+          "type": "STRING",
+          "links": [
+            1160
+          ]
+        }
+      ],
+      "title": "Segment 1 Prompt",
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.22.0",
+        "Node name for S&R": "PrimitiveStringMultiline",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "input_ue_unconnectable": {},
+          "version": "7.8"
+        }
+      },
+      "widgets_values": [
+        "woman performing a fast deepthroat blowjob on a man, Deepthroat blowjob. Hardcore fast blowjob. She pushes her head forward, shoving the penis completely inside her mouth, the penis enters her mouth till her lips reaching the end. She is doing a deep throat blowjob. She moves her head extremely fast to increase the sexual gratification, "
+      ],
+      "color": "#232",
+      "bgcolor": "#353"
+    },
+    {
+      "id": 994,
+      "type": "CLIPTextEncode",
+      "pos": [
+        -938.7515213609793,
+        432.7770952944534
+      ],
+      "size": [
+        274.03007651084715,
+        125.89909188076172
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 92,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": 1279
+        },
+        {
+          "name": "text",
+          "type": "STRING",
+          "widget": {
+            "name": "text"
+          },
+          "link": 1273
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "slot_index": 0,
+          "links": [
+            1274
+          ]
+        }
+      ],
+      "title": "Positive Prompt",
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.3.45",
+        "Node name for S&R": "CLIPTextEncode",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "She drops her towel, she squeezes her breasts with both hands and moans, her finger are feminine and delicate with bright red nails"
+      ],
+      "color": "#232",
+      "bgcolor": "#353"
+    },
+    {
+      "id": 995,
+      "type": "CLIPTextEncode",
+      "pos": [
+        -420.89007038666495,
+        441.3575338656873
+      ],
+      "size": [
+        274.03007651084715,
+        125.89909188076172
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 95,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": 1278
+        },
+        {
+          "name": "text",
+          "type": "STRING",
+          "widget": {
+            "name": "text"
+          },
+          "link": 1271
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "slot_index": 0,
+          "links": [
+            1275
+          ]
+        }
+      ],
+      "title": "Positive Prompt",
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.3.45",
+        "Node name for S&R": "CLIPTextEncode",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "She drops her towel, she squeezes her breasts with both hands and moans, her finger are feminine and delicate with bright red nails"
+      ],
+      "color": "#232",
+      "bgcolor": "#353"
+    },
+    {
+      "id": 990,
+      "type": "PrimitiveStringMultiline",
+      "pos": [
+        -468.725317344301,
+        -133.9266815826677
+      ],
+      "size": [
+        400,
+        200
+      ],
+      "flags": {},
+      "order": 64,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "STRING",
+          "type": "STRING",
+          "links": [
+            1272
+          ]
+        }
+      ],
+      "title": "Segment 2 Prompt",
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.22.0",
+        "Node name for S&R": "PrimitiveStringMultiline",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "input_ue_unconnectable": {},
+          "version": "7.8"
+        }
+      },
+      "widgets_values": [
+        "woman performing a fast deepthroat blowjob on a man, Deepthroat blowjob. Hardcore fast blowjob. She pushes her head forward, shoving the penis completely inside her mouth, the penis enters her mouth till her lips reaching the end. She is doing a deep throat blowjob. She moves her head extremely fast to increase the sexual gratification, "
+      ],
+      "color": "#232",
+      "bgcolor": "#353"
+    },
+    {
+      "id": 996,
+      "type": "SetNode",
+      "pos": [
+        -717.7806187133564,
+        432.89998610003676
+      ],
+      "size": [
+        210,
+        60
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 107,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "link": 1274
+        }
+      ],
+      "outputs": [
+        {
+          "name": "*",
+          "type": "*",
+          "links": null
+        }
+      ],
+      "title": "Set_pos_3",
+      "properties": {
+        "previousName": "pos_3",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "pos_3"
+      ]
+    },
+    {
+      "id": 997,
+      "type": "SetNode",
+      "pos": [
+        -219.2461540275474,
+        441.8178119740505
+      ],
+      "size": [
+        210,
+        50
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 108,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "link": 1275
+        }
+      ],
+      "outputs": [
+        {
+          "name": "*",
+          "type": "*",
+          "links": null
+        }
+      ],
+      "title": "Set_pos_4",
+      "properties": {
+        "previousName": "pos_4",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "pos_4"
+      ]
+    },
+    {
+      "id": 998,
+      "type": "SetNode",
+      "pos": [
+        -221.14310462620435,
+        115.94680240356809
+      ],
+      "size": [
+        210,
+        50
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 106,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "link": 1276
+        }
+      ],
+      "outputs": [
+        {
+          "name": "*",
+          "type": "*",
+          "links": null
+        }
+      ],
+      "title": "Set_pos_2",
+      "properties": {
+        "previousName": "pos_2",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "pos_2"
+      ]
+    },
+    {
+      "id": 954,
+      "type": "GetNode",
+      "pos": [
+        89.1997882657398,
+        -207.5600687806626
+      ],
+      "size": [
+        210,
+        60
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 65,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": [
+            1207
+          ]
+        }
+      ],
+      "title": "Get_pos_2",
+      "properties": {
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "pos_2"
+      ],
+      "color": "#2a363b",
+      "bgcolor": "#3f5159"
+    },
+    {
+      "id": 956,
+      "type": "GetNode",
+      "pos": [
+        87.58753045323982,
+        353.9526655943373
+      ],
+      "size": [
+        210,
+        58
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 66,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": [
+            1191
+          ]
+        }
+      ],
+      "title": "Get_pos_3",
+      "properties": {
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "pos_3"
+      ],
+      "color": "#2a363b",
+      "bgcolor": "#3f5159"
+    },
+    {
+      "id": 957,
+      "type": "GetNode",
+      "pos": [
+        97.67291232230218,
+        946.7678593068376
+      ],
+      "size": [
+        210,
+        58
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 67,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": [
+            1179
+          ]
+        }
+      ],
+      "title": "Get_pos_4",
+      "properties": {
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "pos_4"
+      ],
+      "color": "#2a363b",
+      "bgcolor": "#3f5159"
+    },
+    {
+      "id": 887,
+      "type": "ImageResizeKJv2",
+      "pos": [
+        -525.6980241809263,
+        -1009.7825939555703
+      ],
+      "size": [
+        270,
+        336
+      ],
+      "flags": {},
+      "order": 84,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "image",
+          "type": "IMAGE",
+          "link": 1013
+        },
+        {
+          "name": "mask",
+          "shape": 7,
+          "type": "MASK",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": [
+            1014
+          ]
+        },
+        {
+          "name": "width",
+          "type": "INT",
+          "links": null
+        },
+        {
+          "name": "height",
+          "type": "INT",
+          "links": null
+        },
+        {
+          "name": "mask",
+          "type": "MASK",
+          "links": null
+        }
+      ],
+      "title": "Resize input to SVI resolution",
+      "properties": {
+        "cnr_id": "comfyui-kjnodes",
+        "ver": "204f6d5aae73b10c0fe2fb26e61405fd6337bb77",
+        "Node name for S&R": "ImageResizeKJv2",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "input_ue_unconnectable": {},
+          "version": "7.8"
+        }
+      },
+      "widgets_values": [
+        720,
+        1280,
+        "nearest-exact",
+        "resize",
+        "0, 0, 0",
+        "center",
+        16,
+        "cpu"
+      ]
+    },
+    {
+      "id": 991,
+      "type": "PrimitiveStringMultiline",
+      "pos": [
+        -951.34329724663,
+        178.46379080651326
+      ],
+      "size": [
+        400,
+        200
+      ],
+      "flags": {},
+      "order": 68,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "STRING",
+          "type": "STRING",
+          "links": [
+            1273
+          ]
+        }
+      ],
+      "title": "Segment 3 Prompt",
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.22.0",
+        "Node name for S&R": "PrimitiveStringMultiline",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "input_ue_unconnectable": {},
+          "version": "7.8"
+        }
+      },
+      "widgets_values": [
+        "She takes her head up and looks at the viewer, her hands moves from the bottom of the frame and grabbing the shaft of his erect penis, she is giving him a handjob, her hand moves up and down in rapid motion."
+      ],
+      "color": "#232",
+      "bgcolor": "#353"
+    },
+    {
+      "id": 993,
+      "type": "CLIPTextEncode",
+      "pos": [
+        -456.0904582505366,
+        116.0127968346487
+      ],
+      "size": [
+        274.03007651084715,
+        125.89909188076172
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 91,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": 1277
+        },
+        {
+          "name": "text",
+          "type": "STRING",
+          "widget": {
+            "name": "text"
+          },
+          "link": 1272
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "slot_index": 0,
+          "links": [
+            1276
+          ]
+        }
+      ],
+      "title": "Positive Prompt",
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.3.45",
+        "Node name for S&R": "CLIPTextEncode",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "She drops her towel, she squeezes her breasts with both hands and moans, her finger are feminine and delicate with bright red nails"
+      ],
+      "color": "#232",
+      "bgcolor": "#353"
+    },
+    {
+      "id": 137,
+      "type": "GetNode",
+      "pos": [
+        -580.8490082183074,
+        -184.62103098086075
+      ],
+      "size": [
+        210,
+        58
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 69,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "CLIP",
+          "type": "CLIP",
+          "links": [
+            1015,
+            1016,
+            1277,
+            1278,
+            1279
+          ]
+        }
+      ],
+      "title": "Get_load clip",
+      "properties": {
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "load clip"
+      ],
+      "color": "#432",
+      "bgcolor": "#653"
+    },
+    {
+      "id": 964,
+      "type": "bd9d3c66-e1a6-4739-ab20-46bf80f5ed01",
+      "pos": [
+        486.3084267110102,
+        -397.96497958967535
+      ],
+      "size": [
+        210,
+        318
+      ],
+      "flags": {},
+      "order": 102,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "model",
+          "type": "MODEL",
+          "link": 1199
+        },
+        {
+          "name": "steps",
+          "type": "INT",
+          "widget": {
+            "name": "steps"
+          },
+          "link": 1200
+        },
+        {
+          "name": "cfg",
+          "type": "FLOAT",
+          "widget": {
+            "name": "cfg"
+          },
+          "link": 1201
+        },
+        {
+          "name": "end_at_step",
+          "type": "INT",
+          "widget": {
+            "name": "end_at_step"
+          },
+          "link": 1202
+        },
+        {
+          "name": "model_1",
+          "type": "MODEL",
+          "link": 1203
+        },
+        {
+          "name": "end_at_step_1",
+          "type": "INT",
+          "widget": {
+            "name": "end_at_step_1"
+          },
+          "link": 1204
+        },
+        {
+          "name": "vae",
+          "type": "VAE",
+          "link": 1205
+        },
+        {
+          "name": "model_2",
+          "type": "MODEL",
+          "link": 1206
+        },
+        {
+          "name": "positive",
+          "type": "CONDITIONING",
+          "link": 1207
+        },
+        {
+          "name": "negative",
+          "type": "CONDITIONING",
+          "link": 1208
+        },
+        {
+          "name": "anchor_samples",
+          "type": "LATENT",
+          "link": 1209
+        },
+        {
+          "name": "prev_samples",
+          "shape": 7,
+          "type": "LATENT",
+          "link": 1225
+        },
+        {
+          "name": "length",
+          "type": "INT",
+          "widget": {
+            "name": "length"
+          },
+          "link": 1231
+        },
+        {
+          "label": "seed",
+          "name": "value",
+          "type": "INT",
+          "widget": {
+            "name": "value"
+          },
+          "link": 1265
+        }
+      ],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": [
+            1211
+          ]
+        },
+        {
+          "name": "LATENT",
+          "type": "LATENT",
+          "links": [
+            1212
+          ]
+        }
+      ],
+      "properties": {
+        "proxyWidgets": [
+          [
+            "902",
+            "steps"
+          ],
+          [
+            "902",
+            "cfg"
+          ],
+          [
+            "902",
+            "end_at_step"
+          ],
+          [
+            "907",
+            "end_at_step"
+          ],
+          [
+            "903",
+            "length"
+          ],
+          [
+            "981",
+            "value"
+          ]
+        ],
+        "cnr_id": "comfy-core",
+        "ver": "0.22.0",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "input_ue_unconnectable": {},
+          "version": "7.8"
+        }
+      },
+      "widgets_values": [],
+      "color": "#432",
+      "bgcolor": "#653"
+    },
+    {
+      "id": 965,
+      "type": "5039141f-3a4c-4bb0-ab99-08a1c26e5177",
+      "pos": [
+        479.39155818171383,
+        -932.9732282342068
+      ],
+      "size": [
+        210,
+        298
+      ],
+      "flags": {},
+      "order": 80,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "model",
+          "type": "MODEL",
+          "link": 1213
+        },
+        {
+          "name": "steps",
+          "type": "INT",
+          "widget": {
+            "name": "steps"
+          },
+          "link": 1214
+        },
+        {
+          "name": "cfg",
+          "type": "FLOAT",
+          "widget": {
+            "name": "cfg"
+          },
+          "link": 1215
+        },
+        {
+          "name": "end_at_step",
+          "type": "INT",
+          "widget": {
+            "name": "end_at_step"
+          },
+          "link": 1216
+        },
+        {
+          "name": "model_1",
+          "type": "MODEL",
+          "link": 1217
+        },
+        {
+          "name": "end_at_step_1",
+          "type": "INT",
+          "widget": {
+            "name": "end_at_step_1"
+          },
+          "link": 1218
+        },
+        {
+          "name": "vae",
+          "type": "VAE",
+          "link": 1219
+        },
+        {
+          "name": "model_2",
+          "type": "MODEL",
+          "link": 1220
+        },
+        {
+          "name": "positive",
+          "type": "CONDITIONING",
+          "link": 1221
+        },
+        {
+          "name": "negative",
+          "type": "CONDITIONING",
+          "link": 1222
+        },
+        {
+          "name": "anchor_samples",
+          "type": "LATENT",
+          "link": 1223
+        },
+        {
+          "name": "length",
+          "type": "INT",
+          "widget": {
+            "name": "length"
+          },
+          "link": 1232
+        },
+        {
+          "label": "seed",
+          "name": "value",
+          "type": "INT",
+          "widget": {
+            "name": "value"
+          },
+          "link": 1266
+        }
+      ],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": [
+            1224
+          ]
+        },
+        {
+          "name": "LATENT",
+          "type": "LATENT",
+          "links": [
+            1225
+          ]
+        }
+      ],
+      "properties": {
+        "proxyWidgets": [
+          [
+            "901",
+            "steps"
+          ],
+          [
+            "901",
+            "cfg"
+          ],
+          [
+            "901",
+            "end_at_step"
+          ],
+          [
+            "894",
+            "end_at_step"
+          ],
+          [
+            "893",
+            "length"
+          ],
+          [
+            "980",
+            "value"
+          ]
+        ],
+        "cnr_id": "comfy-core",
+        "ver": "0.22.0",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "input_ue_unconnectable": {},
+          "version": "7.8"
+        }
+      },
+      "widgets_values": [],
+      "color": "#432",
+      "bgcolor": "#653"
+    },
+    {
+      "id": 963,
+      "type": "dd3e2695-a261-4fcf-aa13-ca81452ad186",
+      "pos": [
+        483.27378830475914,
+        27.425074203293324
+      ],
+      "size": [
+        210,
+        318
+      ],
+      "flags": {},
+      "order": 113,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "model",
+          "type": "MODEL",
+          "link": 1185
+        },
+        {
+          "name": "steps",
+          "type": "INT",
+          "widget": {
+            "name": "steps"
+          },
+          "link": 1186
+        },
+        {
+          "name": "cfg",
+          "type": "FLOAT",
+          "widget": {
+            "name": "cfg"
+          },
+          "link": 1187
+        },
+        {
+          "name": "end_at_step",
+          "type": "INT",
+          "widget": {
+            "name": "end_at_step"
+          },
+          "link": 1188
+        },
+        {
+          "name": "model_1",
+          "type": "MODEL",
+          "link": 1189
+        },
+        {
+          "name": "end_at_step_1",
+          "type": "INT",
+          "widget": {
+            "name": "end_at_step_1"
+          },
+          "link": 1190
+        },
+        {
+          "name": "positive",
+          "type": "CONDITIONING",
+          "link": 1191
+        },
+        {
+          "name": "negative",
+          "type": "CONDITIONING",
+          "link": 1192
+        },
+        {
+          "name": "anchor_samples",
+          "type": "LATENT",
+          "link": 1193
+        },
+        {
+          "name": "prev_samples",
+          "shape": 7,
+          "type": "LATENT",
+          "link": 1212
+        },
+        {
+          "name": "model_2",
+          "type": "MODEL",
+          "link": 1195
+        },
+        {
+          "name": "vae",
+          "type": "VAE",
+          "link": 1196
+        },
+        {
+          "name": "length",
+          "type": "INT",
+          "widget": {
+            "name": "length"
+          },
+          "link": 1233
+        },
+        {
+          "label": "seed",
+          "name": "value",
+          "type": "INT",
+          "widget": {
+            "name": "value"
+          },
+          "link": 1264
+        }
+      ],
+      "outputs": [
+        {
+          "name": "LATENT",
+          "type": "LATENT",
+          "links": [
+            1197
+          ]
+        },
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": [
+            1198
+          ]
+        }
+      ],
+      "properties": {
+        "proxyWidgets": [
+          [
+            "915",
+            "steps"
+          ],
+          [
+            "915",
+            "cfg"
+          ],
+          [
+            "915",
+            "end_at_step"
+          ],
+          [
+            "916",
+            "end_at_step"
+          ],
+          [
+            "914",
+            "length"
+          ],
+          [
+            "982",
+            "value"
+          ]
+        ],
+        "cnr_id": "comfy-core",
+        "ver": "0.22.0",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "input_ue_unconnectable": {},
+          "version": "7.8"
+        }
+      },
+      "widgets_values": [],
+      "color": "#432",
+      "bgcolor": "#653"
+    },
+    {
+      "id": 962,
+      "type": "39409467-1b1d-4d3d-b309-fe5b840d4fce",
+      "pos": [
+        491.4145875093293,
+        613.2263098217322
+      ],
+      "size": [
+        210,
+        318
+      ],
+      "flags": {},
+      "order": 116,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "model",
+          "type": "MODEL",
+          "link": 1172
+        },
+        {
+          "name": "steps",
+          "type": "INT",
+          "widget": {
+            "name": "steps"
+          },
+          "link": 1173
+        },
+        {
+          "name": "cfg",
+          "type": "FLOAT",
+          "widget": {
+            "name": "cfg"
+          },
+          "link": 1174
+        },
+        {
+          "name": "end_at_step",
+          "type": "INT",
+          "widget": {
+            "name": "end_at_step"
+          },
+          "link": 1175
+        },
+        {
+          "name": "model_1",
+          "type": "MODEL",
+          "link": 1176
+        },
+        {
+          "name": "end_at_step_1",
+          "type": "INT",
+          "widget": {
+            "name": "end_at_step_1"
+          },
+          "link": 1177
+        },
+        {
+          "name": "vae",
+          "type": "VAE",
+          "link": 1178
+        },
+        {
+          "name": "positive",
+          "type": "CONDITIONING",
+          "link": 1179
+        },
+        {
+          "name": "negative",
+          "type": "CONDITIONING",
+          "link": 1180
+        },
+        {
+          "name": "anchor_samples",
+          "type": "LATENT",
+          "link": 1181
+        },
+        {
+          "name": "prev_samples",
+          "shape": 7,
+          "type": "LATENT",
+          "link": 1197
+        },
+        {
+          "name": "model_2",
+          "type": "MODEL",
+          "link": 1183
+        },
+        {
+          "name": "length",
+          "type": "INT",
+          "widget": {
+            "name": "length"
+          },
+          "link": 1234
+        },
+        {
+          "label": "seed",
+          "name": "value",
+          "type": "INT",
+          "widget": {
+            "name": "value"
+          },
+          "link": 1267
+        }
+      ],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": [
+            1184
+          ]
+        }
+      ],
+      "properties": {
+        "proxyWidgets": [
+          [
+            "933",
+            "steps"
+          ],
+          [
+            "933",
+            "cfg"
+          ],
+          [
+            "933",
+            "end_at_step"
+          ],
+          [
+            "934",
+            "end_at_step"
+          ],
+          [
+            "932",
+            "length"
+          ],
+          [
+            "983",
+            "value"
+          ]
+        ],
+        "cnr_id": "comfy-core",
+        "ver": "0.22.0",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "input_ue_unconnectable": {},
+          "version": "7.8"
+        }
+      },
+      "widgets_values": [],
+      "color": "#432",
+      "bgcolor": "#653"
+    },
+    {
+      "id": 369,
+      "type": "UnetLoaderGGUF",
+      "pos": [
+        -2989.4355630165305,
+        -507.890676975723
+      ],
+      "size": [
+        379.95251279495085,
+        58
+      ],
+      "flags": {},
+      "order": 70,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": [
+            1269
+          ]
+        }
+      ],
+      "title": "Unet Loader (GGUF) LOW",
+      "properties": {
+        "cnr_id": "ComfyUI-GGUF",
+        "ver": "6b778afdc938427116cb72e683d28e42baf67082",
+        "Node name for S&R": "UnetLoaderGGUF",
+        "aux_id": "city96/ComfyUI-GGUF",
+        "ue_properties": {
+          "widget_ue_connectable": {
+            "unet_name": true
+          },
+          "version": "7.1",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "wan22EnhancedNSFWSVICamera_nolightningSVICfQ8L.gguf"
+      ],
+      "color": "#223",
+      "bgcolor": "#335"
+    },
+    {
+      "id": 370,
+      "type": "UnetLoaderGGUF",
+      "pos": [
+        -2992.731582515497,
+        -622.7429603564051
+      ],
+      "size": [
+        377.3330028370866,
+        58
+      ],
+      "flags": {},
+      "order": 71,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": [
+            1268
+          ]
+        }
+      ],
+      "title": "Unet Loader (GGUF) HIGH",
+      "properties": {
+        "cnr_id": "ComfyUI-GGUF",
+        "ver": "6b778afdc938427116cb72e683d28e42baf67082",
+        "Node name for S&R": "UnetLoaderGGUF",
+        "aux_id": "city96/ComfyUI-GGUF",
+        "ue_properties": {
+          "widget_ue_connectable": {
+            "unet_name": true
+          },
+          "version": "7.1",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "wan22EnhancedNSFWSVICamera_nolightningSVICfQ8H.gguf"
+      ],
+      "color": "#223",
+      "bgcolor": "#335"
+    },
+    {
+      "id": 992,
+      "type": "PrimitiveStringMultiline",
+      "pos": [
+        -462.1374623504522,
+        185.8089621914212
+      ],
+      "size": [
+        400,
+        200
+      ],
+      "flags": {},
+      "order": 72,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "STRING",
+          "type": "STRING",
+          "links": [
+            1271
+          ]
+        }
+      ],
+      "title": "Segment 4 Prompt",
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.22.0",
+        "Node name for S&R": "PrimitiveStringMultiline",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "input_ue_unconnectable": {},
+          "version": "7.8"
+        }
+      },
+      "widgets_values": [
+        "She takes her head up and looks at the viewer, her hands moves from the bottom of the frame and grabbing the shaft of his erect penis, she is giving him a handjob, her hand moves up and down in rapid motion."
+      ],
+      "color": "#232",
+      "bgcolor": "#353"
+    }
+  ],
+  "links": [
+    [
+      1003,
+      224,
+      0,
+      354,
+      0,
+      "CLIP"
+    ],
+    [
+      1004,
+      225,
+      0,
+      352,
+      0,
+      "VAE"
+    ],
+    [
+      1005,
+      120,
+      0,
+      880,
+      0,
+      "MODEL"
+    ],
+    [
+      1006,
+      880,
+      0,
+      881,
+      0,
+      "MODEL"
+    ],
+    [
+      1007,
+      881,
+      0,
+      883,
+      0,
+      "MODEL"
+    ],
+    [
+      1008,
+      881,
+      0,
+      367,
+      0,
+      "MODEL"
+    ],
+    [
+      1009,
+      883,
+      0,
+      358,
+      0,
+      "MODEL"
+    ],
+    [
+      1010,
+      121,
+      0,
+      882,
+      0,
+      "MODEL"
+    ],
+    [
+      1011,
+      882,
+      0,
+      884,
+      0,
+      "MODEL"
+    ],
+    [
+      1012,
+      884,
+      0,
+      357,
+      0,
+      "MODEL"
+    ],
+    [
+      1013,
+      62,
+      0,
+      887,
+      0,
+      "IMAGE"
+    ],
+    [
+      1014,
+      887,
+      0,
+      138,
+      0,
+      "IMAGE"
+    ],
+    [
+      1015,
+      137,
+      0,
+      891,
+      0,
+      "CLIP"
+    ],
+    [
+      1016,
+      137,
+      0,
+      892,
+      0,
+      "CLIP"
+    ],
+    [
+      1021,
+      139,
+      0,
+      896,
+      0,
+      "IMAGE"
+    ],
+    [
+      1022,
+      131,
+      0,
+      896,
+      1,
+      "VAE"
+    ],
+    [
+      1023,
+      896,
+      0,
+      145,
+      0,
+      "LATENT"
+    ],
+    [
+      1026,
+      314,
+      0,
+      315,
+      0,
+      "FLOAT"
+    ],
+    [
+      1027,
+      195,
+      0,
+      280,
+      0,
+      "INT"
+    ],
+    [
+      1028,
+      193,
+      0,
+      277,
+      0,
+      "INT"
+    ],
+    [
+      1029,
+      194,
+      0,
+      279,
+      0,
+      "INT"
+    ],
+    [
+      1030,
+      126,
+      0,
+      325,
+      0,
+      "MODEL"
+    ],
+    [
+      1031,
+      129,
+      0,
+      275,
+      0,
+      "MODEL"
+    ],
+    [
+      1033,
+      128,
+      0,
+      276,
+      0,
+      "MODEL"
+    ],
+    [
+      1094,
+      325,
+      0,
+      400,
+      0,
+      "MODEL"
+    ],
+    [
+      1095,
+      275,
+      0,
+      401,
+      0,
+      "MODEL"
+    ],
+    [
+      1096,
+      276,
+      0,
+      402,
+      0,
+      "MODEL"
+    ],
+    [
+      1127,
+      906,
+      2,
+      931,
+      0,
+      "IMAGE"
+    ],
+    [
+      1157,
+      931,
+      2,
+      949,
+      0,
+      "IMAGE"
+    ],
+    [
+      1160,
+      950,
+      0,
+      891,
+      1,
+      "STRING"
+    ],
+    [
+      1161,
+      951,
+      0,
+      892,
+      1,
+      "STRING"
+    ],
+    [
+      1162,
+      891,
+      0,
+      952,
+      0,
+      "CONDITIONING"
+    ],
+    [
+      1163,
+      892,
+      0,
+      953,
+      0,
+      "CONDITIONING"
+    ],
+    [
+      1172,
+      942,
+      0,
+      962,
+      0,
+      "MODEL"
+    ],
+    [
+      1173,
+      945,
+      0,
+      962,
+      1,
+      "INT"
+    ],
+    [
+      1174,
+      948,
+      0,
+      962,
+      2,
+      "FLOAT"
+    ],
+    [
+      1175,
+      946,
+      0,
+      962,
+      3,
+      "INT"
+    ],
+    [
+      1176,
+      943,
+      0,
+      962,
+      4,
+      "MODEL"
+    ],
+    [
+      1177,
+      947,
+      0,
+      962,
+      5,
+      "INT"
+    ],
+    [
+      1178,
+      941,
+      0,
+      962,
+      6,
+      "VAE"
+    ],
+    [
+      1179,
+      957,
+      0,
+      962,
+      7,
+      "CONDITIONING"
+    ],
+    [
+      1180,
+      959,
+      0,
+      962,
+      8,
+      "CONDITIONING"
+    ],
+    [
+      1181,
+      939,
+      0,
+      962,
+      9,
+      "LATENT"
+    ],
+    [
+      1183,
+      944,
+      0,
+      962,
+      11,
+      "MODEL"
+    ],
+    [
+      1184,
+      962,
+      0,
+      949,
+      1,
+      "IMAGE"
+    ],
+    [
+      1185,
+      924,
+      0,
+      963,
+      0,
+      "MODEL"
+    ],
+    [
+      1186,
+      927,
+      0,
+      963,
+      1,
+      "INT"
+    ],
+    [
+      1187,
+      930,
+      0,
+      963,
+      2,
+      "FLOAT"
+    ],
+    [
+      1188,
+      928,
+      0,
+      963,
+      3,
+      "INT"
+    ],
+    [
+      1189,
+      925,
+      0,
+      963,
+      4,
+      "MODEL"
+    ],
+    [
+      1190,
+      929,
+      0,
+      963,
+      5,
+      "INT"
+    ],
+    [
+      1191,
+      956,
+      0,
+      963,
+      6,
+      "CONDITIONING"
+    ],
+    [
+      1192,
+      958,
+      0,
+      963,
+      7,
+      "CONDITIONING"
+    ],
+    [
+      1193,
+      921,
+      0,
+      963,
+      8,
+      "LATENT"
+    ],
+    [
+      1195,
+      926,
+      0,
+      963,
+      10,
+      "MODEL"
+    ],
+    [
+      1196,
+      923,
+      0,
+      963,
+      11,
+      "VAE"
+    ],
+    [
+      1197,
+      963,
+      0,
+      962,
+      10,
+      "LATENT"
+    ],
+    [
+      1198,
+      963,
+      1,
+      931,
+      1,
+      "IMAGE"
+    ],
+    [
+      1199,
+      410,
+      0,
+      964,
+      0,
+      "MODEL"
+    ],
+    [
+      1200,
+      308,
+      0,
+      964,
+      1,
+      "INT"
+    ],
+    [
+      1201,
+      317,
+      0,
+      964,
+      2,
+      "FLOAT"
+    ],
+    [
+      1202,
+      288,
+      0,
+      964,
+      3,
+      "INT"
+    ],
+    [
+      1203,
+      411,
+      0,
+      964,
+      4,
+      "MODEL"
+    ],
+    [
+      1204,
+      290,
+      0,
+      964,
+      5,
+      "INT"
+    ],
+    [
+      1205,
+      197,
+      0,
+      964,
+      6,
+      "VAE"
+    ],
+    [
+      1206,
+      412,
+      0,
+      964,
+      7,
+      "MODEL"
+    ],
+    [
+      1207,
+      954,
+      0,
+      964,
+      8,
+      "CONDITIONING"
+    ],
+    [
+      1208,
+      960,
+      0,
+      964,
+      9,
+      "CONDITIONING"
+    ],
+    [
+      1209,
+      200,
+      0,
+      964,
+      10,
+      "LATENT"
+    ],
+    [
+      1211,
+      964,
+      0,
+      906,
+      1,
+      "IMAGE"
+    ],
+    [
+      1212,
+      964,
+      1,
+      963,
+      9,
+      "LATENT"
+    ],
+    [
+      1213,
+      410,
+      0,
+      965,
+      0,
+      "MODEL"
+    ],
+    [
+      1214,
+      282,
+      0,
+      965,
+      1,
+      "INT"
+    ],
+    [
+      1215,
+      316,
+      0,
+      965,
+      2,
+      "FLOAT"
+    ],
+    [
+      1216,
+      278,
+      0,
+      965,
+      3,
+      "INT"
+    ],
+    [
+      1217,
+      411,
+      0,
+      965,
+      4,
+      "MODEL"
+    ],
+    [
+      1218,
+      285,
+      0,
+      965,
+      5,
+      "INT"
+    ],
+    [
+      1219,
+      130,
+      0,
+      965,
+      6,
+      "VAE"
+    ],
+    [
+      1220,
+      412,
+      0,
+      965,
+      7,
+      "MODEL"
+    ],
+    [
+      1221,
+      955,
+      0,
+      965,
+      8,
+      "CONDITIONING"
+    ],
+    [
+      1222,
+      961,
+      0,
+      965,
+      9,
+      "CONDITIONING"
+    ],
+    [
+      1223,
+      146,
+      0,
+      965,
+      10,
+      "LATENT"
+    ],
+    [
+      1224,
+      965,
+      0,
+      906,
+      0,
+      "IMAGE"
+    ],
+    [
+      1225,
+      965,
+      1,
+      964,
+      11,
+      "LATENT"
+    ],
+    [
+      1230,
+      966,
+      0,
+      967,
+      0,
+      "INT"
+    ],
+    [
+      1231,
+      968,
+      0,
+      964,
+      12,
+      "INT"
+    ],
+    [
+      1232,
+      969,
+      0,
+      965,
+      11,
+      "INT"
+    ],
+    [
+      1233,
+      970,
+      0,
+      963,
+      12,
+      "INT"
+    ],
+    [
+      1234,
+      971,
+      0,
+      962,
+      12,
+      "INT"
+    ],
+    [
+      1243,
+      949,
+      2,
+      977,
+      0,
+      "IMAGE"
+    ],
+    [
+      1244,
+      977,
+      0,
+      512,
+      0,
+      "IMAGE"
+    ],
+    [
+      1263,
+      984,
+      0,
+      985,
+      0,
+      "INT"
+    ],
+    [
+      1264,
+      986,
+      0,
+      963,
+      13,
+      "INT"
+    ],
+    [
+      1265,
+      986,
+      0,
+      964,
+      13,
+      "INT"
+    ],
+    [
+      1266,
+      987,
+      0,
+      965,
+      12,
+      "INT"
+    ],
+    [
+      1267,
+      988,
+      0,
+      962,
+      13,
+      "INT"
+    ],
+    [
+      1268,
+      370,
+      0,
+      113,
+      0,
+      "MODEL"
+    ],
+    [
+      1269,
+      369,
+      0,
+      114,
+      0,
+      "MODEL"
+    ],
+    [
+      1270,
+      906,
+      2,
+      989,
+      0,
+      "IMAGE"
+    ],
+    [
+      1271,
+      992,
+      0,
+      995,
+      1,
+      "STRING"
+    ],
+    [
+      1272,
+      990,
+      0,
+      993,
+      1,
+      "STRING"
+    ],
+    [
+      1273,
+      991,
+      0,
+      994,
+      1,
+      "STRING"
+    ],
+    [
+      1274,
+      994,
+      0,
+      996,
+      0,
+      "CONDITIONING"
+    ],
+    [
+      1275,
+      995,
+      0,
+      997,
+      0,
+      "CONDITIONING"
+    ],
+    [
+      1276,
+      993,
+      0,
+      998,
+      0,
+      "CONDITIONING"
+    ],
+    [
+      1277,
+      137,
+      0,
+      993,
+      0,
+      "CLIP"
+    ],
+    [
+      1278,
+      137,
+      0,
+      995,
+      0,
+      "CLIP"
+    ],
+    [
+      1279,
+      137,
+      0,
+      994,
+      0,
+      "CLIP"
+    ]
+  ],
+  "groups": [
+    {
+      "id": 1,
+      "title": "Loaders",
+      "bounding": [
+        -3010,
+        -720,
+        1990.6968526562496,
+        783.0763257421875
+      ],
+      "color": "#b58b2a",
+      "flags": {}
+    },
+    {
+      "id": 4,
+      "title": "Global Settings",
+      "bounding": [
+        -975.6980241809262,
+        -1109.7825939555705,
+        1023.42064265625,
+        822.3088541406252
+      ],
+      "color": "#ff5900",
+      "flags": {}
+    },
+    {
+      "id": 5,
+      "title": "1st Pass",
+      "bounding": [
+        61.32305293952665,
+        -1135.8354040974907,
+        3342.981841120554,
+        2238.3632893367158
+      ],
+      "color": "#3f789e",
+      "flags": {}
+    },
+    {
+      "id": 6,
+      "title": "Prompts",
+      "bounding": [
+        -975.6945581257585,
+        -273.9880584305987,
+        1023.42064265625,
+        822.3088541406252
+      ],
+      "color": "#ff5900",
+      "flags": {}
+    }
+  ],
+  "definitions": {
+    "subgraphs": [
+      {
+        "id": "39409467-1b1d-4d3d-b309-fe5b840d4fce",
+        "version": 1,
+        "state": {
+          "lastGroupId": 6,
+          "lastNodeId": 998,
+          "lastLinkId": 1279,
+          "lastRerouteId": 0
+        },
+        "revision": 0,
+        "config": {},
+        "name": "Pass 4",
+        "inputNode": {
+          "id": -10,
+          "bounding": [
+            266.0492184058155,
+            588.1329245170448,
+            140.1328125,
+            328
+          ]
+        },
+        "outputNode": {
+          "id": -20,
+          "bounding": [
+            2086.4054649800296,
+            698.1329245170448,
+            128,
+            68
+          ]
+        },
+        "inputs": [
+          {
+            "id": "dc428b16-1ae5-4502-8060-b74c6032d21a",
+            "name": "model",
+            "type": "MODEL",
+            "linkIds": [
+              1135
+            ],
+            "localized_name": "model",
+            "pos": [
+              382.1820309058155,
+              612.1329245170448
+            ]
+          },
+          {
+            "id": "5cdfe09a-eaa7-40db-b336-4a10d6061d95",
+            "name": "steps",
+            "type": "INT",
+            "linkIds": [
+              1139,
+              1146,
+              1153
+            ],
+            "localized_name": "steps",
+            "pos": [
+              382.1820309058155,
+              632.1329245170448
+            ]
+          },
+          {
+            "id": "f355d298-db25-408d-98ad-c71f48550d9e",
+            "name": "cfg",
+            "type": "FLOAT",
+            "linkIds": [
+              1140
+            ],
+            "localized_name": "cfg",
+            "pos": [
+              382.1820309058155,
+              652.1329245170448
+            ]
+          },
+          {
+            "id": "70cd0aa6-bf2e-4fa1-ae87-a7d87378f64c",
+            "name": "end_at_step",
+            "type": "INT",
+            "linkIds": [
+              1141,
+              1147
+            ],
+            "localized_name": "end_at_step",
+            "pos": [
+              382.1820309058155,
+              672.1329245170448
+            ]
+          },
+          {
+            "id": "5d0b4724-267a-47f4-be86-2a0e94339ecb",
+            "name": "model_1",
+            "type": "MODEL",
+            "linkIds": [
+              1142
+            ],
+            "localized_name": "model_1",
+            "pos": [
+              382.1820309058155,
+              692.1329245170448
+            ]
+          },
+          {
+            "id": "07e35491-d95a-4d77-b245-fcb6d2d8af39",
+            "name": "end_at_step_1",
+            "type": "INT",
+            "linkIds": [
+              1148,
+              1154
+            ],
+            "localized_name": "end_at_step_1",
+            "pos": [
+              382.1820309058155,
+              712.1329245170448
+            ]
+          },
+          {
+            "id": "ce7c9600-0a45-46f1-b263-e2b8f5f56450",
+            "name": "vae",
+            "type": "VAE",
+            "linkIds": [
+              1156
+            ],
+            "localized_name": "vae",
+            "pos": [
+              382.1820309058155,
+              732.1329245170448
+            ]
+          },
+          {
+            "id": "f56da746-70a2-4898-8361-c8380e5b1dc7",
+            "name": "positive",
+            "type": "CONDITIONING",
+            "linkIds": [
+              1167
+            ],
+            "localized_name": "positive",
+            "pos": [
+              382.1820309058155,
+              752.1329245170448
+            ]
+          },
+          {
+            "id": "48eaf3b6-d6d4-4c81-bed9-21f350971930",
+            "name": "negative",
+            "type": "CONDITIONING",
+            "linkIds": [
+              1169
+            ],
+            "localized_name": "negative",
+            "pos": [
+              382.1820309058155,
+              772.1329245170448
+            ]
+          },
+          {
+            "id": "b810cbad-99df-47d4-bf1f-4bd1ed66ab4d",
+            "name": "anchor_samples",
+            "type": "LATENT",
+            "linkIds": [
+              1133
+            ],
+            "localized_name": "anchor_samples",
+            "pos": [
+              382.1820309058155,
+              792.1329245170448
+            ]
+          },
+          {
+            "id": "68042d68-1ead-42f4-98c4-e5e338015de2",
+            "name": "prev_samples",
+            "type": "LATENT",
+            "linkIds": [
+              1134
+            ],
+            "localized_name": "prev_samples",
+            "shape": 7,
+            "pos": [
+              382.1820309058155,
+              812.1329245170448
+            ]
+          },
+          {
+            "id": "e5c2bfdb-1f75-4d6e-a4ef-a94eeafd1400",
+            "name": "model_2",
+            "type": "MODEL",
+            "linkIds": [
+              1149
+            ],
+            "localized_name": "model_2",
+            "pos": [
+              382.1820309058155,
+              832.1329245170448
+            ]
+          },
+          {
+            "id": "cd27fa36-296a-4acc-a13d-a8acbbf5403e",
+            "name": "length",
+            "type": "INT",
+            "linkIds": [
+              1229
+            ],
+            "pos": [
+              382.1820309058155,
+              852.1329245170448
+            ]
+          },
+          {
+            "id": "6930dcc0-829f-47b8-a5f6-9649adfc6f4c",
+            "name": "value",
+            "type": "INT",
+            "linkIds": [
+              1262
+            ],
+            "label": "seed",
+            "pos": [
+              382.1820309058155,
+              872.1329245170448
+            ]
+          }
+        ],
+        "outputs": [
+          {
+            "id": "beb74bf6-6150-4933-9db8-769cf7d85190",
+            "name": "IMAGE",
+            "type": "IMAGE",
+            "linkIds": [
+              1158
+            ],
+            "localized_name": "IMAGE",
+            "pos": [
+              2110.4054649800296,
+              722.1329245170448
+            ]
+          }
+        ],
+        "widgets": [],
+        "nodes": [
+          {
+            "id": 933,
+            "type": "KSamplerAdvanced",
+            "pos": [
+              812.2675777808146,
+              581.5594870170447
+            ],
+            "size": [
+              252.353515625,
+              334
+            ],
+            "flags": {},
+            "order": 1,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "model",
+                "name": "model",
+                "type": "MODEL",
+                "link": 1135
+              },
+              {
+                "localized_name": "positive",
+                "name": "positive",
+                "type": "CONDITIONING",
+                "link": 1136
+              },
+              {
+                "localized_name": "negative",
+                "name": "negative",
+                "type": "CONDITIONING",
+                "link": 1137
+              },
+              {
+                "localized_name": "latent_image",
+                "name": "latent_image",
+                "type": "LATENT",
+                "link": 1138
+              },
+              {
+                "localized_name": "noise_seed",
+                "name": "noise_seed",
+                "type": "INT",
+                "widget": {
+                  "name": "noise_seed"
+                },
+                "link": 1259
+              },
+              {
+                "localized_name": "steps",
+                "name": "steps",
+                "type": "INT",
+                "widget": {
+                  "name": "steps"
+                },
+                "link": 1139
+              },
+              {
+                "localized_name": "cfg",
+                "name": "cfg",
+                "type": "FLOAT",
+                "widget": {
+                  "name": "cfg"
+                },
+                "link": 1140
+              },
+              {
+                "localized_name": "end_at_step",
+                "name": "end_at_step",
+                "type": "INT",
+                "widget": {
+                  "name": "end_at_step"
+                },
+                "link": 1141
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "LATENT",
+                "name": "LATENT",
+                "type": "LATENT",
+                "links": [
+                  1145
+                ]
+              }
+            ],
+            "title": "Pass 4 - 1. just SVI",
+            "properties": {
+              "cnr_id": "comfy-core",
+              "ver": "0.3.45",
+              "Node name for S&R": "KSamplerAdvanced",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.1",
+                "input_ue_unconnectable": {}
+              }
+            },
+            "widgets_values": [
+              "enable",
+              394132039161713,
+              "randomize",
+              7,
+              4,
+              "euler",
+              "simple",
+              0,
+              1,
+              "enable"
+            ]
+          },
+          {
+            "id": 936,
+            "type": "VAEDecode",
+            "pos": [
+              1886.4054649800296,
+              608.5204309857946
+            ],
+            "size": [
+              140,
+              48.621998838299646
+            ],
+            "flags": {
+              "collapsed": false
+            },
+            "order": 4,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "samples",
+                "name": "samples",
+                "type": "LATENT",
+                "link": 1155
+              },
+              {
+                "localized_name": "vae",
+                "name": "vae",
+                "type": "VAE",
+                "link": 1156
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "IMAGE",
+                "name": "IMAGE",
+                "type": "IMAGE",
+                "slot_index": 0,
+                "links": [
+                  1158
+                ]
+              }
+            ],
+            "title": "Decode Pass 4",
+            "properties": {
+              "cnr_id": "comfy-core",
+              "ver": "0.3.45",
+              "Node name for S&R": "VAEDecode",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              }
+            },
+            "widgets_values": []
+          },
+          {
+            "id": 932,
+            "type": "WanImageToVideoSVIPro",
+            "pos": [
+              466.1820309058155,
+              578.706362017045
+            ],
+            "size": [
+              277.80078125,
+              142
+            ],
+            "flags": {},
+            "order": 0,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "positive",
+                "name": "positive",
+                "type": "CONDITIONING",
+                "link": 1167
+              },
+              {
+                "localized_name": "negative",
+                "name": "negative",
+                "type": "CONDITIONING",
+                "link": 1169
+              },
+              {
+                "localized_name": "anchor_samples",
+                "name": "anchor_samples",
+                "type": "LATENT",
+                "link": 1133
+              },
+              {
+                "localized_name": "prev_samples",
+                "name": "prev_samples",
+                "shape": 7,
+                "type": "LATENT",
+                "link": 1134
+              },
+              {
+                "localized_name": "length",
+                "name": "length",
+                "type": "INT",
+                "widget": {
+                  "name": "length"
+                },
+                "link": 1229
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "positive",
+                "name": "positive",
+                "type": "CONDITIONING",
+                "links": [
+                  1136,
+                  1143,
+                  1150
+                ]
+              },
+              {
+                "localized_name": "negative",
+                "name": "negative",
+                "type": "CONDITIONING",
+                "links": [
+                  1137,
+                  1144,
+                  1151
+                ]
+              },
+              {
+                "localized_name": "latent",
+                "name": "latent",
+                "type": "LATENT",
+                "links": [
+                  1138
+                ]
+              }
+            ],
+            "title": "Pass 4 SVI latent",
+            "properties": {
+              "cnr_id": "comfyui-kjnodes",
+              "ver": "7b1327192e4729085788a3020a9cbb095e0c7811",
+              "Node name for S&R": "WanImageToVideoSVIPro",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              }
+            },
+            "widgets_values": [
+              17,
+              1
+            ]
+          },
+          {
+            "id": 983,
+            "type": "PrimitiveInt",
+            "pos": [
+              482.3518326912453,
+              844.2597507027575
+            ],
+            "size": [
+              270,
+              82
+            ],
+            "flags": {},
+            "order": 5,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "value",
+                "name": "value",
+                "type": "INT",
+                "widget": {
+                  "name": "value"
+                },
+                "link": 1262
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "INT",
+                "name": "INT",
+                "type": "INT",
+                "links": [
+                  1259,
+                  1260,
+                  1261
+                ]
+              }
+            ],
+            "properties": {
+              "cnr_id": "comfy-core",
+              "ver": "0.22.0",
+              "Node name for S&R": "PrimitiveInt",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "input_ue_unconnectable": {},
+                "version": "7.8"
+              }
+            },
+            "widgets_values": [
+              0,
+              "fixed"
+            ]
+          },
+          {
+            "id": 934,
+            "type": "KSamplerAdvanced",
+            "pos": [
+              1162.2675777808192,
+              581.5594870170447
+            ],
+            "size": [
+              300.526953125,
+              334
+            ],
+            "flags": {},
+            "order": 2,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "model",
+                "name": "model",
+                "type": "MODEL",
+                "link": 1142
+              },
+              {
+                "localized_name": "positive",
+                "name": "positive",
+                "type": "CONDITIONING",
+                "link": 1143
+              },
+              {
+                "localized_name": "negative",
+                "name": "negative",
+                "type": "CONDITIONING",
+                "link": 1144
+              },
+              {
+                "localized_name": "latent_image",
+                "name": "latent_image",
+                "type": "LATENT",
+                "link": 1145
+              },
+              {
+                "localized_name": "noise_seed",
+                "name": "noise_seed",
+                "type": "INT",
+                "widget": {
+                  "name": "noise_seed"
+                },
+                "link": 1260
+              },
+              {
+                "localized_name": "steps",
+                "name": "steps",
+                "type": "INT",
+                "widget": {
+                  "name": "steps"
+                },
+                "link": 1146
+              },
+              {
+                "localized_name": "start_at_step",
+                "name": "start_at_step",
+                "type": "INT",
+                "widget": {
+                  "name": "start_at_step"
+                },
+                "link": 1147
+              },
+              {
+                "localized_name": "end_at_step",
+                "name": "end_at_step",
+                "type": "INT",
+                "widget": {
+                  "name": "end_at_step"
+                },
+                "link": 1148
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "LATENT",
+                "name": "LATENT",
+                "type": "LATENT",
+                "links": [
+                  1152
+                ]
+              }
+            ],
+            "title": "Pass 4 - 2. SVI lightning high",
+            "properties": {
+              "cnr_id": "comfy-core",
+              "ver": "0.3.45",
+              "Node name for S&R": "KSamplerAdvanced",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.1",
+                "input_ue_unconnectable": {}
+              }
+            },
+            "widgets_values": [
+              "disable",
+              189616120811297,
+              "randomize",
+              7,
+              1,
+              "euler",
+              "simple",
+              1,
+              4,
+              "enable"
+            ]
+          },
+          {
+            "id": 935,
+            "type": "KSamplerAdvanced",
+            "pos": [
+              1512.2675777808192,
+              581.5594870170447
+            ],
+            "size": [
+              294.9830078125,
+              334
+            ],
+            "flags": {},
+            "order": 3,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "model",
+                "name": "model",
+                "type": "MODEL",
+                "link": 1149
+              },
+              {
+                "localized_name": "positive",
+                "name": "positive",
+                "type": "CONDITIONING",
+                "link": 1150
+              },
+              {
+                "localized_name": "negative",
+                "name": "negative",
+                "type": "CONDITIONING",
+                "link": 1151
+              },
+              {
+                "localized_name": "latent_image",
+                "name": "latent_image",
+                "type": "LATENT",
+                "link": 1152
+              },
+              {
+                "localized_name": "noise_seed",
+                "name": "noise_seed",
+                "type": "INT",
+                "widget": {
+                  "name": "noise_seed"
+                },
+                "link": 1261
+              },
+              {
+                "localized_name": "steps",
+                "name": "steps",
+                "type": "INT",
+                "widget": {
+                  "name": "steps"
+                },
+                "link": 1153
+              },
+              {
+                "localized_name": "start_at_step",
+                "name": "start_at_step",
+                "type": "INT",
+                "widget": {
+                  "name": "start_at_step"
+                },
+                "link": 1154
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "LATENT",
+                "name": "LATENT",
+                "type": "LATENT",
+                "links": [
+                  1155
+                ]
+              }
+            ],
+            "title": "Pass 4 - 3. SVI lightning low",
+            "properties": {
+              "cnr_id": "comfy-core",
+              "ver": "0.3.45",
+              "Node name for S&R": "KSamplerAdvanced",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.1",
+                "input_ue_unconnectable": {}
+              }
+            },
+            "widgets_values": [
+              "disable",
+              1031673857253078,
+              "randomize",
+              7,
+              1,
+              "er_sde",
+              "simple",
+              4,
+              1000,
+              "disable"
+            ]
+          }
+        ],
+        "groups": [],
+        "links": [
+          {
+            "id": 1136,
+            "origin_id": 932,
+            "origin_slot": 0,
+            "target_id": 933,
+            "target_slot": 1,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 1137,
+            "origin_id": 932,
+            "origin_slot": 1,
+            "target_id": 933,
+            "target_slot": 2,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 1138,
+            "origin_id": 932,
+            "origin_slot": 2,
+            "target_id": 933,
+            "target_slot": 3,
+            "type": "LATENT"
+          },
+          {
+            "id": 1143,
+            "origin_id": 932,
+            "origin_slot": 0,
+            "target_id": 934,
+            "target_slot": 1,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 1144,
+            "origin_id": 932,
+            "origin_slot": 1,
+            "target_id": 934,
+            "target_slot": 2,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 1145,
+            "origin_id": 933,
+            "origin_slot": 0,
+            "target_id": 934,
+            "target_slot": 3,
+            "type": "LATENT"
+          },
+          {
+            "id": 1155,
+            "origin_id": 935,
+            "origin_slot": 0,
+            "target_id": 936,
+            "target_slot": 0,
+            "type": "LATENT"
+          },
+          {
+            "id": 1150,
+            "origin_id": 932,
+            "origin_slot": 0,
+            "target_id": 935,
+            "target_slot": 1,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 1151,
+            "origin_id": 932,
+            "origin_slot": 1,
+            "target_id": 935,
+            "target_slot": 2,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 1152,
+            "origin_id": 934,
+            "origin_slot": 0,
+            "target_id": 935,
+            "target_slot": 3,
+            "type": "LATENT"
+          },
+          {
+            "id": 1135,
+            "origin_id": -10,
+            "origin_slot": 0,
+            "target_id": 933,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 1139,
+            "origin_id": -10,
+            "origin_slot": 1,
+            "target_id": 933,
+            "target_slot": 5,
+            "type": "INT"
+          },
+          {
+            "id": 1146,
+            "origin_id": -10,
+            "origin_slot": 1,
+            "target_id": 934,
+            "target_slot": 5,
+            "type": "INT"
+          },
+          {
+            "id": 1153,
+            "origin_id": -10,
+            "origin_slot": 1,
+            "target_id": 935,
+            "target_slot": 5,
+            "type": "INT"
+          },
+          {
+            "id": 1140,
+            "origin_id": -10,
+            "origin_slot": 2,
+            "target_id": 933,
+            "target_slot": 6,
+            "type": "FLOAT"
+          },
+          {
+            "id": 1141,
+            "origin_id": -10,
+            "origin_slot": 3,
+            "target_id": 933,
+            "target_slot": 7,
+            "type": "INT"
+          },
+          {
+            "id": 1147,
+            "origin_id": -10,
+            "origin_slot": 3,
+            "target_id": 934,
+            "target_slot": 6,
+            "type": "INT"
+          },
+          {
+            "id": 1142,
+            "origin_id": -10,
+            "origin_slot": 4,
+            "target_id": 934,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 1148,
+            "origin_id": -10,
+            "origin_slot": 5,
+            "target_id": 934,
+            "target_slot": 7,
+            "type": "INT"
+          },
+          {
+            "id": 1154,
+            "origin_id": -10,
+            "origin_slot": 5,
+            "target_id": 935,
+            "target_slot": 6,
+            "type": "INT"
+          },
+          {
+            "id": 1156,
+            "origin_id": -10,
+            "origin_slot": 6,
+            "target_id": 936,
+            "target_slot": 1,
+            "type": "VAE"
+          },
+          {
+            "id": 1167,
+            "origin_id": -10,
+            "origin_slot": 7,
+            "target_id": 932,
+            "target_slot": 0,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 1169,
+            "origin_id": -10,
+            "origin_slot": 8,
+            "target_id": 932,
+            "target_slot": 1,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 1133,
+            "origin_id": -10,
+            "origin_slot": 9,
+            "target_id": 932,
+            "target_slot": 2,
+            "type": "LATENT"
+          },
+          {
+            "id": 1134,
+            "origin_id": -10,
+            "origin_slot": 10,
+            "target_id": 932,
+            "target_slot": 3,
+            "type": "LATENT"
+          },
+          {
+            "id": 1149,
+            "origin_id": -10,
+            "origin_slot": 11,
+            "target_id": 935,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 1158,
+            "origin_id": 936,
+            "origin_slot": 0,
+            "target_id": -20,
+            "target_slot": 0,
+            "type": "IMAGE"
+          },
+          {
+            "id": 1229,
+            "origin_id": -10,
+            "origin_slot": 12,
+            "target_id": 932,
+            "target_slot": 4,
+            "type": "INT"
+          },
+          {
+            "id": 1259,
+            "origin_id": 983,
+            "origin_slot": 0,
+            "target_id": 933,
+            "target_slot": 4,
+            "type": "INT"
+          },
+          {
+            "id": 1260,
+            "origin_id": 983,
+            "origin_slot": 0,
+            "target_id": 934,
+            "target_slot": 4,
+            "type": "INT"
+          },
+          {
+            "id": 1261,
+            "origin_id": 983,
+            "origin_slot": 0,
+            "target_id": 935,
+            "target_slot": 4,
+            "type": "INT"
+          },
+          {
+            "id": 1262,
+            "origin_id": -10,
+            "origin_slot": 13,
+            "target_id": 983,
+            "target_slot": 0,
+            "type": "INT"
+          }
+        ],
+        "extra": {
+          "ue_links": [],
+          "links_added_by_ue": []
+        }
+      },
+      {
+        "id": "dd3e2695-a261-4fcf-aa13-ca81452ad186",
+        "version": 1,
+        "state": {
+          "lastGroupId": 6,
+          "lastNodeId": 998,
+          "lastLinkId": 1279,
+          "lastRerouteId": 0
+        },
+        "revision": 0,
+        "config": {},
+        "name": "Pass 3",
+        "inputNode": {
+          "id": -10,
+          "bounding": [
+            231.62144849811898,
+            2.331688898605819,
+            140.1328125,
+            328
+          ]
+        },
+        "outputNode": {
+          "id": -20,
+          "bounding": [
+            2104.5516364785863,
+            102.33168889860582,
+            128,
+            88
+          ]
+        },
+        "inputs": [
+          {
+            "id": "1905ef91-d12e-4453-a5ba-aec00f6daa58",
+            "name": "model",
+            "type": "MODEL",
+            "linkIds": [
+              1105
+            ],
+            "localized_name": "model",
+            "pos": [
+              347.754260998119,
+              26.33168889860582
+            ]
+          },
+          {
+            "id": "5527fbdb-7482-4fa7-949e-7f197fca2387",
+            "name": "steps",
+            "type": "INT",
+            "linkIds": [
+              1109,
+              1116,
+              1123
+            ],
+            "localized_name": "steps",
+            "pos": [
+              347.754260998119,
+              46.33168889860582
+            ]
+          },
+          {
+            "id": "e4a255f3-8fa3-402c-abc9-a1c5a44326da",
+            "name": "cfg",
+            "type": "FLOAT",
+            "linkIds": [
+              1110
+            ],
+            "localized_name": "cfg",
+            "pos": [
+              347.754260998119,
+              66.33168889860582
+            ]
+          },
+          {
+            "id": "2688e205-a00c-485c-a04c-66f83b078f37",
+            "name": "end_at_step",
+            "type": "INT",
+            "linkIds": [
+              1111,
+              1117
+            ],
+            "localized_name": "end_at_step",
+            "pos": [
+              347.754260998119,
+              86.33168889860582
+            ]
+          },
+          {
+            "id": "4dc0ca2f-5ffc-479d-ba6c-df413214739e",
+            "name": "model_1",
+            "type": "MODEL",
+            "linkIds": [
+              1112
+            ],
+            "localized_name": "model_1",
+            "pos": [
+              347.754260998119,
+              106.33168889860582
+            ]
+          },
+          {
+            "id": "5401eec2-6903-4577-8570-e10f4a9ff029",
+            "name": "end_at_step_1",
+            "type": "INT",
+            "linkIds": [
+              1118,
+              1124
+            ],
+            "localized_name": "end_at_step_1",
+            "pos": [
+              347.754260998119,
+              126.33168889860582
+            ]
+          },
+          {
+            "id": "5df16098-165f-4df8-a8e4-618fc13344f0",
+            "name": "positive",
+            "type": "CONDITIONING",
+            "linkIds": [
+              1166
+            ],
+            "localized_name": "positive",
+            "pos": [
+              347.754260998119,
+              146.33168889860582
+            ]
+          },
+          {
+            "id": "733f4abc-aaa1-4f05-8711-3280a6b5f58e",
+            "name": "negative",
+            "type": "CONDITIONING",
+            "linkIds": [
+              1168
+            ],
+            "localized_name": "negative",
+            "pos": [
+              347.754260998119,
+              166.33168889860582
+            ]
+          },
+          {
+            "id": "e3c79bbf-38fc-49ba-b7f3-b51ce2260fd7",
+            "name": "anchor_samples",
+            "type": "LATENT",
+            "linkIds": [
+              1103
+            ],
+            "localized_name": "anchor_samples",
+            "pos": [
+              347.754260998119,
+              186.33168889860582
+            ]
+          },
+          {
+            "id": "5db8c8b3-b34a-47e7-8a3e-f9c0ca2cb7c7",
+            "name": "prev_samples",
+            "type": "LATENT",
+            "linkIds": [
+              1104
+            ],
+            "localized_name": "prev_samples",
+            "shape": 7,
+            "pos": [
+              347.754260998119,
+              206.33168889860582
+            ]
+          },
+          {
+            "id": "70e79851-05b5-438f-83dd-a37e5a20ee0d",
+            "name": "model_2",
+            "type": "MODEL",
+            "linkIds": [
+              1119
+            ],
+            "localized_name": "model_2",
+            "pos": [
+              347.754260998119,
+              226.33168889860582
+            ]
+          },
+          {
+            "id": "46a47c53-00b2-4c91-b25f-f987bfc728a2",
+            "name": "vae",
+            "type": "VAE",
+            "linkIds": [
+              1126
+            ],
+            "localized_name": "vae",
+            "pos": [
+              347.754260998119,
+              246.33168889860582
+            ]
+          },
+          {
+            "id": "70b52034-4c6a-49b7-9916-3fe0f0b93ce0",
+            "name": "length",
+            "type": "INT",
+            "linkIds": [
+              1228
+            ],
+            "pos": [
+              347.754260998119,
+              266.3316888986058
+            ]
+          },
+          {
+            "id": "c07323c9-14bc-4b9a-8dc0-350dd36e4c0c",
+            "name": "value",
+            "type": "INT",
+            "linkIds": [
+              1258
+            ],
+            "label": "seed",
+            "pos": [
+              347.754260998119,
+              286.3316888986058
+            ]
+          }
+        ],
+        "outputs": [
+          {
+            "id": "fb5eb921-dad6-4c46-93dd-4aded6eed58b",
+            "name": "LATENT",
+            "type": "LATENT",
+            "linkIds": [
+              1182
+            ],
+            "localized_name": "LATENT",
+            "pos": [
+              2128.5516364785863,
+              126.33168889860582
+            ]
+          },
+          {
+            "id": "1363c753-7138-4c8d-b508-581603f6be80",
+            "name": "IMAGE",
+            "type": "IMAGE",
+            "linkIds": [
+              1128
+            ],
+            "localized_name": "IMAGE",
+            "pos": [
+              2128.5516364785863,
+              146.33168889860582
+            ]
+          }
+        ],
+        "widgets": [],
+        "nodes": [
+          {
+            "id": 915,
+            "type": "KSamplerAdvanced",
+            "pos": [
+              781.7542609981164,
+              -5.668311101394177
+            ],
+            "size": [
+              252.353515625,
+              334
+            ],
+            "flags": {},
+            "order": 1,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "model",
+                "name": "model",
+                "type": "MODEL",
+                "link": 1105
+              },
+              {
+                "localized_name": "positive",
+                "name": "positive",
+                "type": "CONDITIONING",
+                "link": 1106
+              },
+              {
+                "localized_name": "negative",
+                "name": "negative",
+                "type": "CONDITIONING",
+                "link": 1107
+              },
+              {
+                "localized_name": "latent_image",
+                "name": "latent_image",
+                "type": "LATENT",
+                "link": 1108
+              },
+              {
+                "localized_name": "noise_seed",
+                "name": "noise_seed",
+                "type": "INT",
+                "widget": {
+                  "name": "noise_seed"
+                },
+                "link": 1255
+              },
+              {
+                "localized_name": "steps",
+                "name": "steps",
+                "type": "INT",
+                "widget": {
+                  "name": "steps"
+                },
+                "link": 1109
+              },
+              {
+                "localized_name": "cfg",
+                "name": "cfg",
+                "type": "FLOAT",
+                "widget": {
+                  "name": "cfg"
+                },
+                "link": 1110
+              },
+              {
+                "localized_name": "end_at_step",
+                "name": "end_at_step",
+                "type": "INT",
+                "widget": {
+                  "name": "end_at_step"
+                },
+                "link": 1111
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "LATENT",
+                "name": "LATENT",
+                "type": "LATENT",
+                "links": [
+                  1115
+                ]
+              }
+            ],
+            "title": "Pass 3 - 1. just SVI",
+            "properties": {
+              "cnr_id": "comfy-core",
+              "ver": "0.3.45",
+              "Node name for S&R": "KSamplerAdvanced",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.1",
+                "input_ue_unconnectable": {}
+              }
+            },
+            "widgets_values": [
+              "enable",
+              573948098253711,
+              "randomize",
+              7,
+              4,
+              "euler",
+              "simple",
+              0,
+              1,
+              "enable"
+            ]
+          },
+          {
+            "id": 918,
+            "type": "VAEDecode",
+            "pos": [
+              1904.551636478586,
+              6.560126617355716
+            ],
+            "size": [
+              140,
+              48.621998838299646
+            ],
+            "flags": {
+              "collapsed": false
+            },
+            "order": 4,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "samples",
+                "name": "samples",
+                "type": "LATENT",
+                "link": 1125
+              },
+              {
+                "localized_name": "vae",
+                "name": "vae",
+                "type": "VAE",
+                "link": 1126
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "IMAGE",
+                "name": "IMAGE",
+                "type": "IMAGE",
+                "slot_index": 0,
+                "links": [
+                  1128
+                ]
+              }
+            ],
+            "title": "Decode Pass 3",
+            "properties": {
+              "cnr_id": "comfy-core",
+              "ver": "0.3.45",
+              "Node name for S&R": "VAEDecode",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              }
+            },
+            "widgets_values": []
+          },
+          {
+            "id": 914,
+            "type": "WanImageToVideoSVIPro",
+            "pos": [
+              431.754260998119,
+              -5.668311101394177
+            ],
+            "size": [
+              277.80078125,
+              142
+            ],
+            "flags": {},
+            "order": 0,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "positive",
+                "name": "positive",
+                "type": "CONDITIONING",
+                "link": 1166
+              },
+              {
+                "localized_name": "negative",
+                "name": "negative",
+                "type": "CONDITIONING",
+                "link": 1168
+              },
+              {
+                "localized_name": "anchor_samples",
+                "name": "anchor_samples",
+                "type": "LATENT",
+                "link": 1103
+              },
+              {
+                "localized_name": "prev_samples",
+                "name": "prev_samples",
+                "shape": 7,
+                "type": "LATENT",
+                "link": 1104
+              },
+              {
+                "localized_name": "length",
+                "name": "length",
+                "type": "INT",
+                "widget": {
+                  "name": "length"
+                },
+                "link": 1228
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "positive",
+                "name": "positive",
+                "type": "CONDITIONING",
+                "links": [
+                  1106,
+                  1113,
+                  1120
+                ]
+              },
+              {
+                "localized_name": "negative",
+                "name": "negative",
+                "type": "CONDITIONING",
+                "links": [
+                  1107,
+                  1114,
+                  1121
+                ]
+              },
+              {
+                "localized_name": "latent",
+                "name": "latent",
+                "type": "LATENT",
+                "links": [
+                  1108
+                ]
+              }
+            ],
+            "title": "Pass 3 SVI latent",
+            "properties": {
+              "cnr_id": "comfyui-kjnodes",
+              "ver": "7b1327192e4729085788a3020a9cbb095e0c7811",
+              "Node name for S&R": "WanImageToVideoSVIPro",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              }
+            },
+            "widgets_values": [
+              17,
+              1
+            ]
+          },
+          {
+            "id": 982,
+            "type": "PrimitiveInt",
+            "pos": [
+              438.0916430675435,
+              200.9054095695793
+            ],
+            "size": [
+              270,
+              82
+            ],
+            "flags": {},
+            "order": 5,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "value",
+                "name": "value",
+                "type": "INT",
+                "widget": {
+                  "name": "value"
+                },
+                "link": 1258
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "INT",
+                "name": "INT",
+                "type": "INT",
+                "links": [
+                  1255,
+                  1256,
+                  1257
+                ]
+              }
+            ],
+            "properties": {
+              "cnr_id": "comfy-core",
+              "ver": "0.22.0",
+              "Node name for S&R": "PrimitiveInt",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "input_ue_unconnectable": {},
+                "version": "7.8"
+              }
+            },
+            "widgets_values": [
+              0,
+              "fixed"
+            ]
+          },
+          {
+            "id": 916,
+            "type": "KSamplerAdvanced",
+            "pos": [
+              1131.7542609981188,
+              -5.668311101394177
+            ],
+            "size": [
+              300.526953125,
+              334
+            ],
+            "flags": {},
+            "order": 2,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "model",
+                "name": "model",
+                "type": "MODEL",
+                "link": 1112
+              },
+              {
+                "localized_name": "positive",
+                "name": "positive",
+                "type": "CONDITIONING",
+                "link": 1113
+              },
+              {
+                "localized_name": "negative",
+                "name": "negative",
+                "type": "CONDITIONING",
+                "link": 1114
+              },
+              {
+                "localized_name": "latent_image",
+                "name": "latent_image",
+                "type": "LATENT",
+                "link": 1115
+              },
+              {
+                "localized_name": "noise_seed",
+                "name": "noise_seed",
+                "type": "INT",
+                "widget": {
+                  "name": "noise_seed"
+                },
+                "link": 1256
+              },
+              {
+                "localized_name": "steps",
+                "name": "steps",
+                "type": "INT",
+                "widget": {
+                  "name": "steps"
+                },
+                "link": 1116
+              },
+              {
+                "localized_name": "start_at_step",
+                "name": "start_at_step",
+                "type": "INT",
+                "widget": {
+                  "name": "start_at_step"
+                },
+                "link": 1117
+              },
+              {
+                "localized_name": "end_at_step",
+                "name": "end_at_step",
+                "type": "INT",
+                "widget": {
+                  "name": "end_at_step"
+                },
+                "link": 1118
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "LATENT",
+                "name": "LATENT",
+                "type": "LATENT",
+                "links": [
+                  1122
+                ]
+              }
+            ],
+            "title": "Pass 3 - 2. SVI lightning high",
+            "properties": {
+              "cnr_id": "comfy-core",
+              "ver": "0.3.45",
+              "Node name for S&R": "KSamplerAdvanced",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.1",
+                "input_ue_unconnectable": {}
+              }
+            },
+            "widgets_values": [
+              "disable",
+              1124211454672392,
+              "randomize",
+              7,
+              1,
+              "euler",
+              "simple",
+              1,
+              4,
+              "enable"
+            ]
+          },
+          {
+            "id": 917,
+            "type": "KSamplerAdvanced",
+            "pos": [
+              1481.7542609981188,
+              -5.668311101394177
+            ],
+            "size": [
+              294.9830078125,
+              334
+            ],
+            "flags": {},
+            "order": 3,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "model",
+                "name": "model",
+                "type": "MODEL",
+                "link": 1119
+              },
+              {
+                "localized_name": "positive",
+                "name": "positive",
+                "type": "CONDITIONING",
+                "link": 1120
+              },
+              {
+                "localized_name": "negative",
+                "name": "negative",
+                "type": "CONDITIONING",
+                "link": 1121
+              },
+              {
+                "localized_name": "latent_image",
+                "name": "latent_image",
+                "type": "LATENT",
+                "link": 1122
+              },
+              {
+                "localized_name": "noise_seed",
+                "name": "noise_seed",
+                "type": "INT",
+                "widget": {
+                  "name": "noise_seed"
+                },
+                "link": 1257
+              },
+              {
+                "localized_name": "steps",
+                "name": "steps",
+                "type": "INT",
+                "widget": {
+                  "name": "steps"
+                },
+                "link": 1123
+              },
+              {
+                "localized_name": "start_at_step",
+                "name": "start_at_step",
+                "type": "INT",
+                "widget": {
+                  "name": "start_at_step"
+                },
+                "link": 1124
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "LATENT",
+                "name": "LATENT",
+                "type": "LATENT",
+                "links": [
+                  1125,
+                  1182
+                ]
+              }
+            ],
+            "title": "Pass 3 - 3. SVI lightning low",
+            "properties": {
+              "cnr_id": "comfy-core",
+              "ver": "0.3.45",
+              "Node name for S&R": "KSamplerAdvanced",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.1",
+                "input_ue_unconnectable": {}
+              }
+            },
+            "widgets_values": [
+              "disable",
+              981695791445879,
+              "randomize",
+              7,
+              1,
+              "er_sde",
+              "simple",
+              4,
+              1000,
+              "disable"
+            ]
+          }
+        ],
+        "groups": [],
+        "links": [
+          {
+            "id": 1106,
+            "origin_id": 914,
+            "origin_slot": 0,
+            "target_id": 915,
+            "target_slot": 1,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 1107,
+            "origin_id": 914,
+            "origin_slot": 1,
+            "target_id": 915,
+            "target_slot": 2,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 1108,
+            "origin_id": 914,
+            "origin_slot": 2,
+            "target_id": 915,
+            "target_slot": 3,
+            "type": "LATENT"
+          },
+          {
+            "id": 1113,
+            "origin_id": 914,
+            "origin_slot": 0,
+            "target_id": 916,
+            "target_slot": 1,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 1114,
+            "origin_id": 914,
+            "origin_slot": 1,
+            "target_id": 916,
+            "target_slot": 2,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 1115,
+            "origin_id": 915,
+            "origin_slot": 0,
+            "target_id": 916,
+            "target_slot": 3,
+            "type": "LATENT"
+          },
+          {
+            "id": 1120,
+            "origin_id": 914,
+            "origin_slot": 0,
+            "target_id": 917,
+            "target_slot": 1,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 1121,
+            "origin_id": 914,
+            "origin_slot": 1,
+            "target_id": 917,
+            "target_slot": 2,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 1122,
+            "origin_id": 916,
+            "origin_slot": 0,
+            "target_id": 917,
+            "target_slot": 3,
+            "type": "LATENT"
+          },
+          {
+            "id": 1125,
+            "origin_id": 917,
+            "origin_slot": 0,
+            "target_id": 918,
+            "target_slot": 0,
+            "type": "LATENT"
+          },
+          {
+            "id": 1105,
+            "origin_id": -10,
+            "origin_slot": 0,
+            "target_id": 915,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 1109,
+            "origin_id": -10,
+            "origin_slot": 1,
+            "target_id": 915,
+            "target_slot": 5,
+            "type": "INT"
+          },
+          {
+            "id": 1116,
+            "origin_id": -10,
+            "origin_slot": 1,
+            "target_id": 916,
+            "target_slot": 5,
+            "type": "INT"
+          },
+          {
+            "id": 1123,
+            "origin_id": -10,
+            "origin_slot": 1,
+            "target_id": 917,
+            "target_slot": 5,
+            "type": "INT"
+          },
+          {
+            "id": 1110,
+            "origin_id": -10,
+            "origin_slot": 2,
+            "target_id": 915,
+            "target_slot": 6,
+            "type": "FLOAT"
+          },
+          {
+            "id": 1111,
+            "origin_id": -10,
+            "origin_slot": 3,
+            "target_id": 915,
+            "target_slot": 7,
+            "type": "INT"
+          },
+          {
+            "id": 1117,
+            "origin_id": -10,
+            "origin_slot": 3,
+            "target_id": 916,
+            "target_slot": 6,
+            "type": "INT"
+          },
+          {
+            "id": 1112,
+            "origin_id": -10,
+            "origin_slot": 4,
+            "target_id": 916,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 1118,
+            "origin_id": -10,
+            "origin_slot": 5,
+            "target_id": 916,
+            "target_slot": 7,
+            "type": "INT"
+          },
+          {
+            "id": 1124,
+            "origin_id": -10,
+            "origin_slot": 5,
+            "target_id": 917,
+            "target_slot": 6,
+            "type": "INT"
+          },
+          {
+            "id": 1166,
+            "origin_id": -10,
+            "origin_slot": 6,
+            "target_id": 914,
+            "target_slot": 0,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 1168,
+            "origin_id": -10,
+            "origin_slot": 7,
+            "target_id": 914,
+            "target_slot": 1,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 1103,
+            "origin_id": -10,
+            "origin_slot": 8,
+            "target_id": 914,
+            "target_slot": 2,
+            "type": "LATENT"
+          },
+          {
+            "id": 1104,
+            "origin_id": -10,
+            "origin_slot": 9,
+            "target_id": 914,
+            "target_slot": 3,
+            "type": "LATENT"
+          },
+          {
+            "id": 1119,
+            "origin_id": -10,
+            "origin_slot": 10,
+            "target_id": 917,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 1126,
+            "origin_id": -10,
+            "origin_slot": 11,
+            "target_id": 918,
+            "target_slot": 1,
+            "type": "VAE"
+          },
+          {
+            "id": 1182,
+            "origin_id": 917,
+            "origin_slot": 0,
+            "target_id": -20,
+            "target_slot": 0,
+            "type": "LATENT"
+          },
+          {
+            "id": 1128,
+            "origin_id": 918,
+            "origin_slot": 0,
+            "target_id": -20,
+            "target_slot": 1,
+            "type": "IMAGE"
+          },
+          {
+            "id": 1228,
+            "origin_id": -10,
+            "origin_slot": 12,
+            "target_id": 914,
+            "target_slot": 4,
+            "type": "INT"
+          },
+          {
+            "id": 1255,
+            "origin_id": 982,
+            "origin_slot": 0,
+            "target_id": 915,
+            "target_slot": 4,
+            "type": "INT"
+          },
+          {
+            "id": 1256,
+            "origin_id": 982,
+            "origin_slot": 0,
+            "target_id": 916,
+            "target_slot": 4,
+            "type": "INT"
+          },
+          {
+            "id": 1257,
+            "origin_id": 982,
+            "origin_slot": 0,
+            "target_id": 917,
+            "target_slot": 4,
+            "type": "INT"
+          },
+          {
+            "id": 1258,
+            "origin_id": -10,
+            "origin_slot": 13,
+            "target_id": 982,
+            "target_slot": 0,
+            "type": "INT"
+          }
+        ],
+        "extra": {
+          "ue_links": [],
+          "links_added_by_ue": []
+        }
+      },
+      {
+        "id": "bd9d3c66-e1a6-4739-ab20-46bf80f5ed01",
+        "version": 1,
+        "state": {
+          "lastGroupId": 6,
+          "lastNodeId": 998,
+          "lastLinkId": 1279,
+          "lastRerouteId": 0
+        },
+        "revision": 0,
+        "config": {},
+        "name": "Pass 2",
+        "inputNode": {
+          "id": -10,
+          "bounding": [
+            256.8059805957757,
+            -472.10846008186286,
+            140.1328125,
+            328
+          ]
+        },
+        "outputNode": {
+          "id": -20,
+          "bounding": [
+            2081.0766802949943,
+            -372.10846008186286,
+            128,
+            88
+          ]
+        },
+        "inputs": [
+          {
+            "id": "cf677b3e-9368-4f49-8e22-e7b2b05b5be0",
+            "name": "model",
+            "type": "MODEL",
+            "linkIds": [
+              1088
+            ],
+            "localized_name": "model",
+            "pos": [
+              372.9387930957757,
+              -448.10846008186286
+            ]
+          },
+          {
+            "id": "7e11bb98-97fe-45be-bec2-36e12142c540",
+            "name": "steps",
+            "type": "INT",
+            "linkIds": [
+              1092,
+              1067,
+              1070
+            ],
+            "localized_name": "steps",
+            "pos": [
+              372.9387930957757,
+              -428.10846008186286
+            ]
+          },
+          {
+            "id": "2c410ce1-84c0-4efe-a4f7-120c1c8ef88b",
+            "name": "cfg",
+            "type": "FLOAT",
+            "linkIds": [
+              1066
+            ],
+            "localized_name": "cfg",
+            "pos": [
+              372.9387930957757,
+              -408.10846008186286
+            ]
+          },
+          {
+            "id": "dd3063f6-d6f6-466d-b1a7-39d8a9205894",
+            "name": "end_at_step",
+            "type": "INT",
+            "linkIds": [
+              1068,
+              1071
+            ],
+            "localized_name": "end_at_step",
+            "pos": [
+              372.9387930957757,
+              -388.10846008186286
+            ]
+          },
+          {
+            "id": "5a17fa42-6be3-40ac-a4cb-0fef77c4bfbb",
+            "name": "model_1",
+            "type": "MODEL",
+            "linkIds": [
+              1087
+            ],
+            "localized_name": "model_1",
+            "pos": [
+              372.9387930957757,
+              -368.10846008186286
+            ]
+          },
+          {
+            "id": "6f83451b-f7f8-4e4c-bc19-209c4b34df50",
+            "name": "end_at_step_1",
+            "type": "INT",
+            "linkIds": [
+              1072,
+              1093
+            ],
+            "localized_name": "end_at_step_1",
+            "pos": [
+              372.9387930957757,
+              -348.10846008186286
+            ]
+          },
+          {
+            "id": "ecbc448c-b0ca-47e7-b5e6-c7b7b376a133",
+            "name": "vae",
+            "type": "VAE",
+            "linkIds": [
+              1077
+            ],
+            "localized_name": "vae",
+            "pos": [
+              372.9387930957757,
+              -328.10846008186286
+            ]
+          },
+          {
+            "id": "8ca8a2f1-ca65-41c4-9de2-84355a107a3a",
+            "name": "model_2",
+            "type": "MODEL",
+            "linkIds": [
+              1074
+            ],
+            "localized_name": "model_2",
+            "pos": [
+              372.9387930957757,
+              -308.10846008186286
+            ]
+          },
+          {
+            "id": "255d2dc4-b00b-44ce-8959-6cf717a6f9d4",
+            "name": "positive",
+            "type": "CONDITIONING",
+            "linkIds": [
+              1164
+            ],
+            "localized_name": "positive",
+            "pos": [
+              372.9387930957757,
+              -288.10846008186286
+            ]
+          },
+          {
+            "id": "72081130-160d-49d4-b48e-a18a04564063",
+            "name": "negative",
+            "type": "CONDITIONING",
+            "linkIds": [
+              1170
+            ],
+            "localized_name": "negative",
+            "pos": [
+              372.9387930957757,
+              -268.10846008186286
+            ]
+          },
+          {
+            "id": "74ae0c79-c7b2-4b0e-a1f1-8429faf5e5f8",
+            "name": "anchor_samples",
+            "type": "LATENT",
+            "linkIds": [
+              1085
+            ],
+            "localized_name": "anchor_samples",
+            "pos": [
+              372.9387930957757,
+              -248.10846008186286
+            ]
+          },
+          {
+            "id": "d0f22315-c8f7-4069-b473-6df7fb6fe583",
+            "name": "prev_samples",
+            "type": "LATENT",
+            "linkIds": [
+              1086
+            ],
+            "localized_name": "prev_samples",
+            "shape": 7,
+            "pos": [
+              372.9387930957757,
+              -228.10846008186286
+            ]
+          },
+          {
+            "id": "2f500226-2769-4d42-a841-a95f2f371e44",
+            "name": "length",
+            "type": "INT",
+            "linkIds": [
+              1226
+            ],
+            "pos": [
+              372.9387930957757,
+              -208.10846008186286
+            ]
+          },
+          {
+            "id": "4cabdbda-b400-46e1-b96b-94111207b6ac",
+            "name": "value",
+            "type": "INT",
+            "linkIds": [
+              1254
+            ],
+            "label": "seed",
+            "pos": [
+              372.9387930957757,
+              -188.10846008186286
+            ]
+          }
+        ],
+        "outputs": [
+          {
+            "id": "44b51028-4e5c-4cfb-9629-a1be70fda9e7",
+            "name": "IMAGE",
+            "type": "IMAGE",
+            "linkIds": [
+              1078
+            ],
+            "localized_name": "IMAGE",
+            "pos": [
+              2105.0766802949943,
+              -348.10846008186286
+            ]
+          },
+          {
+            "id": "60a30e11-303b-4b4e-a0af-d68b2e33f7b4",
+            "name": "LATENT",
+            "type": "LATENT",
+            "linkIds": [
+              1194
+            ],
+            "localized_name": "LATENT",
+            "pos": [
+              2105.0766802949943,
+              -328.10846008186286
+            ]
+          }
+        ],
+        "widgets": [],
+        "nodes": [
+          {
+            "id": 902,
+            "type": "KSamplerAdvanced",
+            "pos": [
+              806.9387930957733,
+              -480.1084600818629
+            ],
+            "size": [
+              252.353515625,
+              334
+            ],
+            "flags": {},
+            "order": 0,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "model",
+                "name": "model",
+                "type": "MODEL",
+                "link": 1088
+              },
+              {
+                "localized_name": "positive",
+                "name": "positive",
+                "type": "CONDITIONING",
+                "link": 1060
+              },
+              {
+                "localized_name": "negative",
+                "name": "negative",
+                "type": "CONDITIONING",
+                "link": 1061
+              },
+              {
+                "localized_name": "latent_image",
+                "name": "latent_image",
+                "type": "LATENT",
+                "link": 1062
+              },
+              {
+                "localized_name": "noise_seed",
+                "name": "noise_seed",
+                "type": "INT",
+                "widget": {
+                  "name": "noise_seed"
+                },
+                "link": 1251
+              },
+              {
+                "localized_name": "steps",
+                "name": "steps",
+                "type": "INT",
+                "widget": {
+                  "name": "steps"
+                },
+                "link": 1092
+              },
+              {
+                "localized_name": "cfg",
+                "name": "cfg",
+                "type": "FLOAT",
+                "widget": {
+                  "name": "cfg"
+                },
+                "link": 1066
+              },
+              {
+                "localized_name": "end_at_step",
+                "name": "end_at_step",
+                "type": "INT",
+                "widget": {
+                  "name": "end_at_step"
+                },
+                "link": 1068
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "LATENT",
+                "name": "LATENT",
+                "type": "LATENT",
+                "links": [
+                  1069
+                ]
+              }
+            ],
+            "title": "Pass 2 - 1. just SVI",
+            "properties": {
+              "cnr_id": "comfy-core",
+              "ver": "0.3.45",
+              "Node name for S&R": "KSamplerAdvanced",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.1",
+                "input_ue_unconnectable": {}
+              }
+            },
+            "widgets_values": [
+              "enable",
+              1061520175490967,
+              "randomize",
+              6,
+              3.5,
+              "euler",
+              "simple",
+              0,
+              1,
+              "enable"
+            ]
+          },
+          {
+            "id": 903,
+            "type": "WanImageToVideoSVIPro",
+            "pos": [
+              456.9387930957757,
+              -480.1084600818629
+            ],
+            "size": [
+              277.80078125,
+              142
+            ],
+            "flags": {},
+            "order": 1,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "positive",
+                "name": "positive",
+                "type": "CONDITIONING",
+                "link": 1164
+              },
+              {
+                "localized_name": "negative",
+                "name": "negative",
+                "type": "CONDITIONING",
+                "link": 1170
+              },
+              {
+                "localized_name": "anchor_samples",
+                "name": "anchor_samples",
+                "type": "LATENT",
+                "link": 1085
+              },
+              {
+                "localized_name": "prev_samples",
+                "name": "prev_samples",
+                "shape": 7,
+                "type": "LATENT",
+                "link": 1086
+              },
+              {
+                "localized_name": "length",
+                "name": "length",
+                "type": "INT",
+                "widget": {
+                  "name": "length"
+                },
+                "link": 1226
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "positive",
+                "name": "positive",
+                "type": "CONDITIONING",
+                "links": [
+                  1060,
+                  1064,
+                  1089
+                ]
+              },
+              {
+                "localized_name": "negative",
+                "name": "negative",
+                "type": "CONDITIONING",
+                "links": [
+                  1061,
+                  1065,
+                  1075
+                ]
+              },
+              {
+                "localized_name": "latent",
+                "name": "latent",
+                "type": "LATENT",
+                "links": [
+                  1062
+                ]
+              }
+            ],
+            "title": "Pass 2 SVI latent",
+            "properties": {
+              "cnr_id": "comfyui-kjnodes",
+              "ver": "7b1327192e4729085788a3020a9cbb095e0c7811",
+              "Node name for S&R": "WanImageToVideoSVIPro",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              }
+            },
+            "widgets_values": [
+              17,
+              1
+            ]
+          },
+          {
+            "id": 981,
+            "type": "PrimitiveInt",
+            "pos": [
+              461.2832377105162,
+              -249.78864617225804
+            ],
+            "size": [
+              270,
+              82
+            ],
+            "flags": {},
+            "order": 5,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "value",
+                "name": "value",
+                "type": "INT",
+                "widget": {
+                  "name": "value"
+                },
+                "link": 1254
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "INT",
+                "name": "INT",
+                "type": "INT",
+                "links": [
+                  1251,
+                  1252,
+                  1253
+                ]
+              }
+            ],
+            "properties": {
+              "cnr_id": "comfy-core",
+              "ver": "0.22.0",
+              "Node name for S&R": "PrimitiveInt",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "input_ue_unconnectable": {},
+                "version": "7.8"
+              }
+            },
+            "widgets_values": [
+              0,
+              "fixed"
+            ]
+          },
+          {
+            "id": 907,
+            "type": "KSamplerAdvanced",
+            "pos": [
+              1156.9387930957766,
+              -480.1084600818629
+            ],
+            "size": [
+              300.526953125,
+              334
+            ],
+            "flags": {},
+            "order": 2,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "model",
+                "name": "model",
+                "type": "MODEL",
+                "link": 1087
+              },
+              {
+                "localized_name": "positive",
+                "name": "positive",
+                "type": "CONDITIONING",
+                "link": 1064
+              },
+              {
+                "localized_name": "negative",
+                "name": "negative",
+                "type": "CONDITIONING",
+                "link": 1065
+              },
+              {
+                "localized_name": "latent_image",
+                "name": "latent_image",
+                "type": "LATENT",
+                "link": 1069
+              },
+              {
+                "localized_name": "noise_seed",
+                "name": "noise_seed",
+                "type": "INT",
+                "widget": {
+                  "name": "noise_seed"
+                },
+                "link": 1252
+              },
+              {
+                "localized_name": "steps",
+                "name": "steps",
+                "type": "INT",
+                "widget": {
+                  "name": "steps"
+                },
+                "link": 1067
+              },
+              {
+                "localized_name": "start_at_step",
+                "name": "start_at_step",
+                "type": "INT",
+                "widget": {
+                  "name": "start_at_step"
+                },
+                "link": 1071
+              },
+              {
+                "localized_name": "end_at_step",
+                "name": "end_at_step",
+                "type": "INT",
+                "widget": {
+                  "name": "end_at_step"
+                },
+                "link": 1072
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "LATENT",
+                "name": "LATENT",
+                "type": "LATENT",
+                "links": [
+                  1073
+                ]
+              }
+            ],
+            "title": "Pass 2 - 2. SVI lightning high",
+            "properties": {
+              "cnr_id": "comfy-core",
+              "ver": "0.3.45",
+              "Node name for S&R": "KSamplerAdvanced",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.1",
+                "input_ue_unconnectable": {}
+              }
+            },
+            "widgets_values": [
+              "disable",
+              1077992683376539,
+              "randomize",
+              6,
+              1,
+              "euler",
+              "simple",
+              1,
+              3,
+              "enable"
+            ]
+          },
+          {
+            "id": 913,
+            "type": "VAEDecode",
+            "pos": [
+              1886.537027735954,
+              -473.36944673348665
+            ],
+            "size": [
+              140,
+              48.621998838299646
+            ],
+            "flags": {
+              "collapsed": false
+            },
+            "order": 4,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "samples",
+                "name": "samples",
+                "type": "LATENT",
+                "link": 1076
+              },
+              {
+                "localized_name": "vae",
+                "name": "vae",
+                "type": "VAE",
+                "link": 1077
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "IMAGE",
+                "name": "IMAGE",
+                "type": "IMAGE",
+                "slot_index": 0,
+                "links": [
+                  1078
+                ]
+              }
+            ],
+            "title": "Decode Pass 2",
+            "properties": {
+              "cnr_id": "comfy-core",
+              "ver": "0.3.45",
+              "Node name for S&R": "VAEDecode",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              }
+            },
+            "widgets_values": []
+          },
+          {
+            "id": 908,
+            "type": "KSamplerAdvanced",
+            "pos": [
+              1506.9387930957766,
+              -480.1084600818629
+            ],
+            "size": [
+              294.9830078125,
+              334
+            ],
+            "flags": {},
+            "order": 3,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "model",
+                "name": "model",
+                "type": "MODEL",
+                "link": 1074
+              },
+              {
+                "localized_name": "positive",
+                "name": "positive",
+                "type": "CONDITIONING",
+                "link": 1089
+              },
+              {
+                "localized_name": "negative",
+                "name": "negative",
+                "type": "CONDITIONING",
+                "link": 1075
+              },
+              {
+                "localized_name": "latent_image",
+                "name": "latent_image",
+                "type": "LATENT",
+                "link": 1073
+              },
+              {
+                "localized_name": "noise_seed",
+                "name": "noise_seed",
+                "type": "INT",
+                "widget": {
+                  "name": "noise_seed"
+                },
+                "link": 1253
+              },
+              {
+                "localized_name": "steps",
+                "name": "steps",
+                "type": "INT",
+                "widget": {
+                  "name": "steps"
+                },
+                "link": 1070
+              },
+              {
+                "localized_name": "start_at_step",
+                "name": "start_at_step",
+                "type": "INT",
+                "widget": {
+                  "name": "start_at_step"
+                },
+                "link": 1093
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "LATENT",
+                "name": "LATENT",
+                "type": "LATENT",
+                "links": [
+                  1076,
+                  1194
+                ]
+              }
+            ],
+            "title": "Pass 2 - 3. SVI lightning low",
+            "properties": {
+              "cnr_id": "comfy-core",
+              "ver": "0.3.45",
+              "Node name for S&R": "KSamplerAdvanced",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.1",
+                "input_ue_unconnectable": {}
+              }
+            },
+            "widgets_values": [
+              "disable",
+              152085848338098,
+              "randomize",
+              6,
+              1,
+              "er_sde",
+              "simple",
+              3,
+              1000,
+              "disable"
+            ]
+          }
+        ],
+        "groups": [],
+        "links": [
+          {
+            "id": 1060,
+            "origin_id": 903,
+            "origin_slot": 0,
+            "target_id": 902,
+            "target_slot": 1,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 1061,
+            "origin_id": 903,
+            "origin_slot": 1,
+            "target_id": 902,
+            "target_slot": 2,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 1062,
+            "origin_id": 903,
+            "origin_slot": 2,
+            "target_id": 902,
+            "target_slot": 3,
+            "type": "LATENT"
+          },
+          {
+            "id": 1064,
+            "origin_id": 903,
+            "origin_slot": 0,
+            "target_id": 907,
+            "target_slot": 1,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 1065,
+            "origin_id": 903,
+            "origin_slot": 1,
+            "target_id": 907,
+            "target_slot": 2,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 1069,
+            "origin_id": 902,
+            "origin_slot": 0,
+            "target_id": 907,
+            "target_slot": 3,
+            "type": "LATENT"
+          },
+          {
+            "id": 1076,
+            "origin_id": 908,
+            "origin_slot": 0,
+            "target_id": 913,
+            "target_slot": 0,
+            "type": "LATENT"
+          },
+          {
+            "id": 1089,
+            "origin_id": 903,
+            "origin_slot": 0,
+            "target_id": 908,
+            "target_slot": 1,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 1075,
+            "origin_id": 903,
+            "origin_slot": 1,
+            "target_id": 908,
+            "target_slot": 2,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 1073,
+            "origin_id": 907,
+            "origin_slot": 0,
+            "target_id": 908,
+            "target_slot": 3,
+            "type": "LATENT"
+          },
+          {
+            "id": 1088,
+            "origin_id": -10,
+            "origin_slot": 0,
+            "target_id": 902,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 1092,
+            "origin_id": -10,
+            "origin_slot": 1,
+            "target_id": 902,
+            "target_slot": 5,
+            "type": "INT"
+          },
+          {
+            "id": 1067,
+            "origin_id": -10,
+            "origin_slot": 1,
+            "target_id": 907,
+            "target_slot": 5,
+            "type": "INT"
+          },
+          {
+            "id": 1070,
+            "origin_id": -10,
+            "origin_slot": 1,
+            "target_id": 908,
+            "target_slot": 5,
+            "type": "INT"
+          },
+          {
+            "id": 1066,
+            "origin_id": -10,
+            "origin_slot": 2,
+            "target_id": 902,
+            "target_slot": 6,
+            "type": "FLOAT"
+          },
+          {
+            "id": 1068,
+            "origin_id": -10,
+            "origin_slot": 3,
+            "target_id": 902,
+            "target_slot": 7,
+            "type": "INT"
+          },
+          {
+            "id": 1071,
+            "origin_id": -10,
+            "origin_slot": 3,
+            "target_id": 907,
+            "target_slot": 6,
+            "type": "INT"
+          },
+          {
+            "id": 1087,
+            "origin_id": -10,
+            "origin_slot": 4,
+            "target_id": 907,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 1072,
+            "origin_id": -10,
+            "origin_slot": 5,
+            "target_id": 907,
+            "target_slot": 7,
+            "type": "INT"
+          },
+          {
+            "id": 1093,
+            "origin_id": -10,
+            "origin_slot": 5,
+            "target_id": 908,
+            "target_slot": 6,
+            "type": "INT"
+          },
+          {
+            "id": 1077,
+            "origin_id": -10,
+            "origin_slot": 6,
+            "target_id": 913,
+            "target_slot": 1,
+            "type": "VAE"
+          },
+          {
+            "id": 1074,
+            "origin_id": -10,
+            "origin_slot": 7,
+            "target_id": 908,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 1164,
+            "origin_id": -10,
+            "origin_slot": 8,
+            "target_id": 903,
+            "target_slot": 0,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 1170,
+            "origin_id": -10,
+            "origin_slot": 9,
+            "target_id": 903,
+            "target_slot": 1,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 1085,
+            "origin_id": -10,
+            "origin_slot": 10,
+            "target_id": 903,
+            "target_slot": 2,
+            "type": "LATENT"
+          },
+          {
+            "id": 1086,
+            "origin_id": -10,
+            "origin_slot": 11,
+            "target_id": 903,
+            "target_slot": 3,
+            "type": "LATENT"
+          },
+          {
+            "id": 1078,
+            "origin_id": 913,
+            "origin_slot": 0,
+            "target_id": -20,
+            "target_slot": 0,
+            "type": "IMAGE"
+          },
+          {
+            "id": 1194,
+            "origin_id": 908,
+            "origin_slot": 0,
+            "target_id": -20,
+            "target_slot": 1,
+            "type": "LATENT"
+          },
+          {
+            "id": 1226,
+            "origin_id": -10,
+            "origin_slot": 12,
+            "target_id": 903,
+            "target_slot": 4,
+            "type": "INT"
+          },
+          {
+            "id": 1251,
+            "origin_id": 981,
+            "origin_slot": 0,
+            "target_id": 902,
+            "target_slot": 4,
+            "type": "INT"
+          },
+          {
+            "id": 1252,
+            "origin_id": 981,
+            "origin_slot": 0,
+            "target_id": 907,
+            "target_slot": 4,
+            "type": "INT"
+          },
+          {
+            "id": 1253,
+            "origin_id": 981,
+            "origin_slot": 0,
+            "target_id": 908,
+            "target_slot": 4,
+            "type": "INT"
+          },
+          {
+            "id": 1254,
+            "origin_id": -10,
+            "origin_slot": 13,
+            "target_id": 981,
+            "target_slot": 0,
+            "type": "INT"
+          }
+        ],
+        "extra": {
+          "ue_links": [],
+          "links_added_by_ue": []
+        }
+      },
+      {
+        "id": "5039141f-3a4c-4bb0-ab99-08a1c26e5177",
+        "version": 1,
+        "state": {
+          "lastGroupId": 6,
+          "lastNodeId": 998,
+          "lastLinkId": 1279,
+          "lastRerouteId": 0
+        },
+        "revision": 0,
+        "config": {},
+        "name": "Pass 1",
+        "inputNode": {
+          "id": -10,
+          "bounding": [
+            216.50231075202674,
+            -893.7298845662382,
+            140.1328125,
+            308
+          ]
+        },
+        "outputNode": {
+          "id": -20,
+          "bounding": [
+            2070.966646494213,
+            -803.7298845662382,
+            128,
+            88
+          ]
+        },
+        "inputs": [
+          {
+            "id": "4c779729-cb35-4559-80bd-8126c6dd14dd",
+            "name": "model",
+            "type": "MODEL",
+            "linkIds": [
+              1036
+            ],
+            "localized_name": "model",
+            "pos": [
+              332.63512325202674,
+              -869.7298845662382
+            ]
+          },
+          {
+            "id": "75be4805-9975-473c-91f2-3b7e6120a35a",
+            "name": "steps",
+            "type": "INT",
+            "linkIds": [
+              1082,
+              1044,
+              1083
+            ],
+            "localized_name": "steps",
+            "pos": [
+              332.63512325202674,
+              -849.7298845662382
+            ]
+          },
+          {
+            "id": "7050b538-e78d-412f-a414-677924381f26",
+            "name": "cfg",
+            "type": "FLOAT",
+            "linkIds": [
+              1043
+            ],
+            "localized_name": "cfg",
+            "pos": [
+              332.63512325202674,
+              -829.7298845662382
+            ]
+          },
+          {
+            "id": "b7d2c72f-38ce-4ef3-b338-bba80bb17fdf",
+            "name": "end_at_step",
+            "type": "INT",
+            "linkIds": [
+              1045,
+              1048
+            ],
+            "localized_name": "end_at_step",
+            "pos": [
+              332.63512325202674,
+              -809.7298845662382
+            ]
+          },
+          {
+            "id": "811e4a5a-0b0b-4dc5-bdc8-6b4c8ae1dc35",
+            "name": "model_1",
+            "type": "MODEL",
+            "linkIds": [
+              1040
+            ],
+            "localized_name": "model_1",
+            "pos": [
+              332.63512325202674,
+              -789.7298845662382
+            ]
+          },
+          {
+            "id": "98796db4-af2a-4e89-b0fd-77fa2e845f4b",
+            "name": "end_at_step_1",
+            "type": "INT",
+            "linkIds": [
+              1049,
+              1084
+            ],
+            "localized_name": "end_at_step_1",
+            "pos": [
+              332.63512325202674,
+              -769.7298845662382
+            ]
+          },
+          {
+            "id": "6ece64bf-4600-43b0-989d-d13a3f1c3b46",
+            "name": "vae",
+            "type": "VAE",
+            "linkIds": [
+              1097
+            ],
+            "localized_name": "vae",
+            "pos": [
+              332.63512325202674,
+              -749.7298845662382
+            ]
+          },
+          {
+            "id": "f7bb1021-2b8d-4bbf-9910-3b42b8e7ddb1",
+            "name": "model_2",
+            "type": "MODEL",
+            "linkIds": [
+              1034
+            ],
+            "localized_name": "model_2",
+            "pos": [
+              332.63512325202674,
+              -729.7298845662382
+            ]
+          },
+          {
+            "id": "6b4a4c27-b40f-4bbc-884a-9d5f37ee01fb",
+            "name": "positive",
+            "type": "CONDITIONING",
+            "linkIds": [
+              1165
+            ],
+            "localized_name": "positive",
+            "pos": [
+              332.63512325202674,
+              -709.7298845662382
+            ]
+          },
+          {
+            "id": "fcb941d4-6d8a-49b8-97f4-630bb03e1d0d",
+            "name": "negative",
+            "type": "CONDITIONING",
+            "linkIds": [
+              1171
+            ],
+            "localized_name": "negative",
+            "pos": [
+              332.63512325202674,
+              -689.7298845662382
+            ]
+          },
+          {
+            "id": "85a8869e-40a7-4c8c-9c32-148ffcf8f309",
+            "name": "anchor_samples",
+            "type": "LATENT",
+            "linkIds": [
+              1035
+            ],
+            "localized_name": "anchor_samples",
+            "pos": [
+              332.63512325202674,
+              -669.7298845662382
+            ]
+          },
+          {
+            "id": "e5d686f0-dcf8-47a7-aba0-52b1df99695c",
+            "name": "length",
+            "type": "INT",
+            "linkIds": [
+              1227
+            ],
+            "pos": [
+              332.63512325202674,
+              -649.7298845662382
+            ]
+          },
+          {
+            "id": "a26552d2-68b1-48b8-b542-99e9cbeed135",
+            "name": "value",
+            "type": "INT",
+            "linkIds": [
+              1250
+            ],
+            "label": "seed",
+            "pos": [
+              332.63512325202674,
+              -629.7298845662382
+            ]
+          }
+        ],
+        "outputs": [
+          {
+            "id": "5374d541-18b2-40c5-a299-7e64fa94568a",
+            "name": "IMAGE",
+            "type": "IMAGE",
+            "linkIds": [
+              1098
+            ],
+            "localized_name": "IMAGE",
+            "pos": [
+              2094.966646494213,
+              -779.7298845662382
+            ]
+          },
+          {
+            "id": "38016f22-49f7-481c-83f0-01b0efceb036",
+            "name": "LATENT",
+            "type": "LATENT",
+            "linkIds": [
+              1210
+            ],
+            "localized_name": "LATENT",
+            "pos": [
+              2094.966646494213,
+              -759.7298845662382
+            ]
+          }
+        ],
+        "widgets": [],
+        "nodes": [
+          {
+            "id": 898,
+            "type": "VAEDecode",
+            "pos": [
+              1870.9666464942131,
+              -765.8726732381133
+            ],
+            "size": [
+              140,
+              48.621998838299646
+            ],
+            "flags": {
+              "collapsed": false
+            },
+            "order": 3,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "samples",
+                "name": "samples",
+                "type": "LATENT",
+                "link": 1053
+              },
+              {
+                "localized_name": "vae",
+                "name": "vae",
+                "type": "VAE",
+                "link": 1097
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "IMAGE",
+                "name": "IMAGE",
+                "type": "IMAGE",
+                "slot_index": 0,
+                "links": [
+                  1098
+                ]
+              }
+            ],
+            "title": "Decode Pass 1",
+            "properties": {
+              "cnr_id": "comfy-core",
+              "ver": "0.3.45",
+              "Node name for S&R": "VAEDecode",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              }
+            },
+            "widgets_values": []
+          },
+          {
+            "id": 893,
+            "type": "WanImageToVideoSVIPro",
+            "pos": [
+              416.63512325202674,
+              -918.6478533162383
+            ],
+            "size": [
+              277.80078125,
+              142
+            ],
+            "flags": {},
+            "order": 0,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "positive",
+                "name": "positive",
+                "type": "CONDITIONING",
+                "link": 1165
+              },
+              {
+                "localized_name": "negative",
+                "name": "negative",
+                "type": "CONDITIONING",
+                "link": 1171
+              },
+              {
+                "localized_name": "anchor_samples",
+                "name": "anchor_samples",
+                "type": "LATENT",
+                "link": 1035
+              },
+              {
+                "localized_name": "prev_samples",
+                "name": "prev_samples",
+                "shape": 7,
+                "type": "LATENT",
+                "link": null
+              },
+              {
+                "localized_name": "length",
+                "name": "length",
+                "type": "INT",
+                "widget": {
+                  "name": "length"
+                },
+                "link": 1227
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "positive",
+                "name": "positive",
+                "type": "CONDITIONING",
+                "links": [
+                  1037,
+                  1041,
+                  1051
+                ]
+              },
+              {
+                "localized_name": "negative",
+                "name": "negative",
+                "type": "CONDITIONING",
+                "links": [
+                  1038,
+                  1042,
+                  1052
+                ]
+              },
+              {
+                "localized_name": "latent",
+                "name": "latent",
+                "type": "LATENT",
+                "links": [
+                  1039
+                ]
+              }
+            ],
+            "title": "Pass 1 SVI latent",
+            "properties": {
+              "cnr_id": "comfyui-kjnodes",
+              "ver": "7b1327192e4729085788a3020a9cbb095e0c7811",
+              "Node name for S&R": "WanImageToVideoSVIPro",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              }
+            },
+            "widgets_values": [
+              17,
+              0
+            ]
+          },
+          {
+            "id": 901,
+            "type": "KSamplerAdvanced",
+            "pos": [
+              796.7132482520263,
+              -904.8119158162381
+            ],
+            "size": [
+              252.353515625,
+              334
+            ],
+            "flags": {},
+            "order": 4,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "model",
+                "name": "model",
+                "type": "MODEL",
+                "link": 1036
+              },
+              {
+                "localized_name": "positive",
+                "name": "positive",
+                "type": "CONDITIONING",
+                "link": 1037
+              },
+              {
+                "localized_name": "negative",
+                "name": "negative",
+                "type": "CONDITIONING",
+                "link": 1038
+              },
+              {
+                "localized_name": "latent_image",
+                "name": "latent_image",
+                "type": "LATENT",
+                "link": 1039
+              },
+              {
+                "localized_name": "noise_seed",
+                "name": "noise_seed",
+                "type": "INT",
+                "widget": {
+                  "name": "noise_seed"
+                },
+                "link": 1247
+              },
+              {
+                "localized_name": "steps",
+                "name": "steps",
+                "type": "INT",
+                "widget": {
+                  "name": "steps"
+                },
+                "link": 1082
+              },
+              {
+                "localized_name": "cfg",
+                "name": "cfg",
+                "type": "FLOAT",
+                "widget": {
+                  "name": "cfg"
+                },
+                "link": 1043
+              },
+              {
+                "localized_name": "end_at_step",
+                "name": "end_at_step",
+                "type": "INT",
+                "widget": {
+                  "name": "end_at_step"
+                },
+                "link": 1045
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "LATENT",
+                "name": "LATENT",
+                "type": "LATENT",
+                "links": [
+                  1047
+                ]
+              }
+            ],
+            "title": "Pass 1 - 1. just SVI",
+            "properties": {
+              "cnr_id": "comfy-core",
+              "ver": "0.3.45",
+              "Node name for S&R": "KSamplerAdvanced",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.1",
+                "input_ue_unconnectable": {}
+              }
+            },
+            "widgets_values": [
+              "enable",
+              1006106922152254,
+              "randomize",
+              6,
+              3.5,
+              "euler",
+              "simple",
+              0,
+              1,
+              "enable"
+            ]
+          },
+          {
+            "id": 980,
+            "type": "PrimitiveInt",
+            "pos": [
+              404.6322356831974,
+              -685.7372995262587
+            ],
+            "size": [
+              270,
+              82
+            ],
+            "flags": {},
+            "order": 5,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "value",
+                "name": "value",
+                "type": "INT",
+                "widget": {
+                  "name": "value"
+                },
+                "link": 1250
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "INT",
+                "name": "INT",
+                "type": "INT",
+                "links": [
+                  1247,
+                  1248,
+                  1249
+                ]
+              }
+            ],
+            "title": "seed",
+            "properties": {
+              "cnr_id": "comfy-core",
+              "ver": "0.22.0",
+              "Node name for S&R": "PrimitiveInt",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "input_ue_unconnectable": {},
+                "version": "7.8"
+              }
+            },
+            "widgets_values": [
+              0,
+              "fixed"
+            ]
+          },
+          {
+            "id": 894,
+            "type": "KSamplerAdvanced",
+            "pos": [
+              1146.7132482520258,
+              -904.8119158162381
+            ],
+            "size": [
+              300.526953125,
+              334
+            ],
+            "flags": {},
+            "order": 1,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "model",
+                "name": "model",
+                "type": "MODEL",
+                "link": 1040
+              },
+              {
+                "localized_name": "positive",
+                "name": "positive",
+                "type": "CONDITIONING",
+                "link": 1041
+              },
+              {
+                "localized_name": "negative",
+                "name": "negative",
+                "type": "CONDITIONING",
+                "link": 1042
+              },
+              {
+                "localized_name": "latent_image",
+                "name": "latent_image",
+                "type": "LATENT",
+                "link": 1047
+              },
+              {
+                "localized_name": "noise_seed",
+                "name": "noise_seed",
+                "type": "INT",
+                "widget": {
+                  "name": "noise_seed"
+                },
+                "link": 1248
+              },
+              {
+                "localized_name": "steps",
+                "name": "steps",
+                "type": "INT",
+                "widget": {
+                  "name": "steps"
+                },
+                "link": 1044
+              },
+              {
+                "localized_name": "start_at_step",
+                "name": "start_at_step",
+                "type": "INT",
+                "widget": {
+                  "name": "start_at_step"
+                },
+                "link": 1048
+              },
+              {
+                "localized_name": "end_at_step",
+                "name": "end_at_step",
+                "type": "INT",
+                "widget": {
+                  "name": "end_at_step"
+                },
+                "link": 1049
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "LATENT",
+                "name": "LATENT",
+                "type": "LATENT",
+                "links": [
+                  1050
+                ]
+              }
+            ],
+            "title": "Pass 1 - 2. SVI lightning high",
+            "properties": {
+              "cnr_id": "comfy-core",
+              "ver": "0.3.45",
+              "Node name for S&R": "KSamplerAdvanced",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.1",
+                "input_ue_unconnectable": {}
+              }
+            },
+            "widgets_values": [
+              "disable",
+              540073779589677,
+              "randomize",
+              6,
+              1,
+              "euler",
+              "simple",
+              1,
+              3,
+              "enable"
+            ]
+          },
+          {
+            "id": 895,
+            "type": "KSamplerAdvanced",
+            "pos": [
+              1496.7132482520262,
+              -904.8119158162381
+            ],
+            "size": [
+              294.9830078125,
+              334
+            ],
+            "flags": {},
+            "order": 2,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "model",
+                "name": "model",
+                "type": "MODEL",
+                "link": 1034
+              },
+              {
+                "localized_name": "positive",
+                "name": "positive",
+                "type": "CONDITIONING",
+                "link": 1051
+              },
+              {
+                "localized_name": "negative",
+                "name": "negative",
+                "type": "CONDITIONING",
+                "link": 1052
+              },
+              {
+                "localized_name": "latent_image",
+                "name": "latent_image",
+                "type": "LATENT",
+                "link": 1050
+              },
+              {
+                "localized_name": "noise_seed",
+                "name": "noise_seed",
+                "type": "INT",
+                "widget": {
+                  "name": "noise_seed"
+                },
+                "link": 1249
+              },
+              {
+                "localized_name": "steps",
+                "name": "steps",
+                "type": "INT",
+                "widget": {
+                  "name": "steps"
+                },
+                "link": 1083
+              },
+              {
+                "localized_name": "start_at_step",
+                "name": "start_at_step",
+                "type": "INT",
+                "widget": {
+                  "name": "start_at_step"
+                },
+                "link": 1084
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "LATENT",
+                "name": "LATENT",
+                "type": "LATENT",
+                "links": [
+                  1053,
+                  1210
+                ]
+              }
+            ],
+            "title": "Pass 1 - 3. SVI lightning low",
+            "properties": {
+              "cnr_id": "comfy-core",
+              "ver": "0.3.45",
+              "Node name for S&R": "KSamplerAdvanced",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.1",
+                "input_ue_unconnectable": {}
+              }
+            },
+            "widgets_values": [
+              "disable",
+              482999158098561,
+              "randomize",
+              6,
+              1,
+              "er_sde",
+              "simple",
+              3,
+              1000,
+              "disable"
+            ]
+          }
+        ],
+        "groups": [],
+        "links": [
+          {
+            "id": 1037,
+            "origin_id": 893,
+            "origin_slot": 0,
+            "target_id": 901,
+            "target_slot": 1,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 1038,
+            "origin_id": 893,
+            "origin_slot": 1,
+            "target_id": 901,
+            "target_slot": 2,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 1039,
+            "origin_id": 893,
+            "origin_slot": 2,
+            "target_id": 901,
+            "target_slot": 3,
+            "type": "LATENT"
+          },
+          {
+            "id": 1041,
+            "origin_id": 893,
+            "origin_slot": 0,
+            "target_id": 894,
+            "target_slot": 1,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 1042,
+            "origin_id": 893,
+            "origin_slot": 1,
+            "target_id": 894,
+            "target_slot": 2,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 1047,
+            "origin_id": 901,
+            "origin_slot": 0,
+            "target_id": 894,
+            "target_slot": 3,
+            "type": "LATENT"
+          },
+          {
+            "id": 1053,
+            "origin_id": 895,
+            "origin_slot": 0,
+            "target_id": 898,
+            "target_slot": 0,
+            "type": "LATENT"
+          },
+          {
+            "id": 1051,
+            "origin_id": 893,
+            "origin_slot": 0,
+            "target_id": 895,
+            "target_slot": 1,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 1052,
+            "origin_id": 893,
+            "origin_slot": 1,
+            "target_id": 895,
+            "target_slot": 2,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 1050,
+            "origin_id": 894,
+            "origin_slot": 0,
+            "target_id": 895,
+            "target_slot": 3,
+            "type": "LATENT"
+          },
+          {
+            "id": 1036,
+            "origin_id": -10,
+            "origin_slot": 0,
+            "target_id": 901,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 1082,
+            "origin_id": -10,
+            "origin_slot": 1,
+            "target_id": 901,
+            "target_slot": 5,
+            "type": "INT"
+          },
+          {
+            "id": 1044,
+            "origin_id": -10,
+            "origin_slot": 1,
+            "target_id": 894,
+            "target_slot": 5,
+            "type": "INT"
+          },
+          {
+            "id": 1083,
+            "origin_id": -10,
+            "origin_slot": 1,
+            "target_id": 895,
+            "target_slot": 5,
+            "type": "INT"
+          },
+          {
+            "id": 1043,
+            "origin_id": -10,
+            "origin_slot": 2,
+            "target_id": 901,
+            "target_slot": 6,
+            "type": "FLOAT"
+          },
+          {
+            "id": 1045,
+            "origin_id": -10,
+            "origin_slot": 3,
+            "target_id": 901,
+            "target_slot": 7,
+            "type": "INT"
+          },
+          {
+            "id": 1048,
+            "origin_id": -10,
+            "origin_slot": 3,
+            "target_id": 894,
+            "target_slot": 6,
+            "type": "INT"
+          },
+          {
+            "id": 1040,
+            "origin_id": -10,
+            "origin_slot": 4,
+            "target_id": 894,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 1049,
+            "origin_id": -10,
+            "origin_slot": 5,
+            "target_id": 894,
+            "target_slot": 7,
+            "type": "INT"
+          },
+          {
+            "id": 1084,
+            "origin_id": -10,
+            "origin_slot": 5,
+            "target_id": 895,
+            "target_slot": 6,
+            "type": "INT"
+          },
+          {
+            "id": 1097,
+            "origin_id": -10,
+            "origin_slot": 6,
+            "target_id": 898,
+            "target_slot": 1,
+            "type": "VAE"
+          },
+          {
+            "id": 1034,
+            "origin_id": -10,
+            "origin_slot": 7,
+            "target_id": 895,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 1165,
+            "origin_id": -10,
+            "origin_slot": 8,
+            "target_id": 893,
+            "target_slot": 0,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 1171,
+            "origin_id": -10,
+            "origin_slot": 9,
+            "target_id": 893,
+            "target_slot": 1,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 1035,
+            "origin_id": -10,
+            "origin_slot": 10,
+            "target_id": 893,
+            "target_slot": 2,
+            "type": "LATENT"
+          },
+          {
+            "id": 1098,
+            "origin_id": 898,
+            "origin_slot": 0,
+            "target_id": -20,
+            "target_slot": 0,
+            "type": "IMAGE"
+          },
+          {
+            "id": 1210,
+            "origin_id": 895,
+            "origin_slot": 0,
+            "target_id": -20,
+            "target_slot": 1,
+            "type": "LATENT"
+          },
+          {
+            "id": 1227,
+            "origin_id": -10,
+            "origin_slot": 11,
+            "target_id": 893,
+            "target_slot": 4,
+            "type": "INT"
+          },
+          {
+            "id": 1247,
+            "origin_id": 980,
+            "origin_slot": 0,
+            "target_id": 901,
+            "target_slot": 4,
+            "type": "INT"
+          },
+          {
+            "id": 1248,
+            "origin_id": 980,
+            "origin_slot": 0,
+            "target_id": 894,
+            "target_slot": 4,
+            "type": "INT"
+          },
+          {
+            "id": 1249,
+            "origin_id": 980,
+            "origin_slot": 0,
+            "target_id": 895,
+            "target_slot": 4,
+            "type": "INT"
+          },
+          {
+            "id": 1250,
+            "origin_id": -10,
+            "origin_slot": 12,
+            "target_id": 980,
+            "target_slot": 0,
+            "type": "INT"
+          }
+        ],
+        "extra": {
+          "ue_links": [],
+          "links_added_by_ue": []
+        }
+      },
+      {
+        "id": "1cde9493-dec3-474f-894d-42eedd890bdd",
+        "version": 1,
+        "state": {
+          "lastGroupId": 6,
+          "lastNodeId": 998,
+          "lastLinkId": 1279,
+          "lastRerouteId": 0
+        },
+        "revision": 0,
+        "config": {},
+        "name": "Upscale + Interpolate",
+        "inputNode": {
+          "id": -10,
+          "bounding": [
+            1167.6038928050903,
+            -468.87222569791584,
+            128,
+            68
+          ]
+        },
+        "outputNode": {
+          "id": -20,
+          "bounding": [
+            1923.9683459300902,
+            -468.87222569791584,
+            128,
+            68
+          ]
+        },
+        "inputs": [
+          {
+            "id": "33a97150-f18e-4559-be51-af7a94153ba9",
+            "name": "image",
+            "type": "IMAGE",
+            "linkIds": [
+              1237,
+              1236
+            ],
+            "localized_name": "image",
+            "pos": [
+              51,
+              24
+            ]
+          }
+        ],
+        "outputs": [
+          {
+            "id": "d9793146-0e5c-465f-8942-9c2b4e642de4",
+            "name": "IMAGE",
+            "type": "IMAGE",
+            "linkIds": [
+              1242
+            ],
+            "localized_name": "IMAGE",
+            "pos": [
+              24,
+              24
+            ]
+          }
+        ],
+        "widgets": [],
+        "nodes": [
+          {
+            "id": 972,
+            "type": "UpscaleModelLoader",
+            "pos": [
+              1368.2535611644646,
+              -691.0331089010409
+            ],
+            "size": [
+              270,
+              58
+            ],
+            "flags": {},
+            "order": 0,
+            "mode": 0,
+            "inputs": [],
+            "outputs": [
+              {
+                "localized_name": "UPSCALE_MODEL",
+                "name": "UPSCALE_MODEL",
+                "type": "UPSCALE_MODEL",
+                "links": [
+                  1235
+                ]
+              }
+            ],
+            "properties": {
+              "cnr_id": "comfy-core",
+              "ver": "0.22.0",
+              "Node name for S&R": "UpscaleModelLoader",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "input_ue_unconnectable": {},
+                "version": "7.8"
+              }
+            },
+            "widgets_values": [
+              "2xLiveActionV1_SPAN_490000.pth"
+            ]
+          },
+          {
+            "id": 975,
+            "type": "GetImageSize",
+            "pos": [
+              1723.9683459300902,
+              -545.6109518697906
+            ],
+            "size": [
+              140,
+              66
+            ],
+            "flags": {},
+            "order": 3,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "image",
+                "name": "image",
+                "type": "IMAGE",
+                "link": 1237
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "width",
+                "name": "width",
+                "type": "INT",
+                "links": [
+                  1239
+                ]
+              },
+              {
+                "localized_name": "height",
+                "name": "height",
+                "type": "INT",
+                "links": [
+                  1238
+                ]
+              },
+              {
+                "localized_name": "batch_size",
+                "name": "batch_size",
+                "type": "INT",
+                "links": null
+              }
+            ],
+            "properties": {
+              "cnr_id": "comfy-core",
+              "ver": "0.22.0",
+              "Node name for S&R": "GetImageSize",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "input_ue_unconnectable": {},
+                "version": "7.8"
+              }
+            },
+            "widgets_values": []
+          },
+          {
+            "id": 974,
+            "type": "ImageUpscaleWithModel",
+            "pos": [
+              1387.74637327384,
+              -582.7101706197907
+            ],
+            "size": [
+              233.5689453125,
+              46
+            ],
+            "flags": {},
+            "order": 2,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "upscale_model",
+                "name": "upscale_model",
+                "type": "UPSCALE_MODEL",
+                "link": 1235
+              },
+              {
+                "localized_name": "image",
+                "name": "image",
+                "type": "IMAGE",
+                "link": 1236
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "IMAGE",
+                "name": "IMAGE",
+                "type": "IMAGE",
+                "links": [
+                  1240
+                ]
+              }
+            ],
+            "properties": {
+              "cnr_id": "comfy-core",
+              "ver": "0.22.0",
+              "Node name for S&R": "ImageUpscaleWithModel",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "input_ue_unconnectable": {},
+                "version": "7.8"
+              }
+            },
+            "widgets_values": []
+          },
+          {
+            "id": 976,
+            "type": "ImageResizeKJv2",
+            "pos": [
+              1423.1251491443086,
+              -488.5519926462278
+            ],
+            "size": [
+              270,
+              286
+            ],
+            "flags": {
+              "collapsed": true
+            },
+            "order": 4,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "image",
+                "name": "image",
+                "type": "IMAGE",
+                "link": 1240
+              },
+              {
+                "localized_name": "mask",
+                "name": "mask",
+                "shape": 7,
+                "type": "MASK",
+                "link": null
+              },
+              {
+                "localized_name": "width",
+                "name": "width",
+                "type": "INT",
+                "widget": {
+                  "name": "width"
+                },
+                "link": 1239
+              },
+              {
+                "localized_name": "height",
+                "name": "height",
+                "type": "INT",
+                "widget": {
+                  "name": "height"
+                },
+                "link": 1238
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "IMAGE",
+                "name": "IMAGE",
+                "type": "IMAGE",
+                "links": [
+                  1241
+                ]
+              },
+              {
+                "localized_name": "width",
+                "name": "width",
+                "type": "INT",
+                "links": null
+              },
+              {
+                "localized_name": "height",
+                "name": "height",
+                "type": "INT",
+                "links": null
+              },
+              {
+                "localized_name": "mask",
+                "name": "mask",
+                "type": "MASK",
+                "links": null
+              }
+            ],
+            "properties": {
+              "cnr_id": "comfyui-kjnodes",
+              "ver": "204f6d5aae73b10c0fe2fb26e61405fd6337bb77",
+              "Node name for S&R": "ImageResizeKJv2",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "input_ue_unconnectable": {},
+                "version": "7.8"
+              }
+            },
+            "widgets_values": [
+              512,
+              512,
+              "nearest-exact",
+              "stretch",
+              "0, 0, 0",
+              "center",
+              2,
+              "cpu"
+            ]
+          },
+          {
+            "id": 973,
+            "type": "RIFE VFI",
+            "pos": [
+              1355.6038928050903,
+              -418.7113424947908
+            ],
+            "size": [
+              321.8046875,
+              270
+            ],
+            "flags": {},
+            "order": 1,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "frames",
+                "name": "frames",
+                "type": "IMAGE",
+                "link": 1241
+              },
+              {
+                "localized_name": "optional_interpolation_states",
+                "name": "optional_interpolation_states",
+                "shape": 7,
+                "type": "INTERPOLATION_STATES",
+                "link": null
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "IMAGE",
+                "name": "IMAGE",
+                "type": "IMAGE",
+                "links": [
+                  1242
+                ]
+              }
+            ],
+            "properties": {
+              "cnr_id": "comfyui-frame-interpolation",
+              "ver": "26545cc2dd95bc3d27f056016300673bdeee78f5",
+              "Node name for S&R": "RIFE VFI",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "input_ue_unconnectable": {},
+                "version": "7.8"
+              }
+            },
+            "widgets_values": [
+              "rife49.pth",
+              5,
+              2,
+              false,
+              true,
+              1,
+              "float16",
+              false,
+              1
+            ]
+          }
+        ],
+        "groups": [],
+        "links": [
+          {
+            "id": 1235,
+            "origin_id": 972,
+            "origin_slot": 0,
+            "target_id": 974,
+            "target_slot": 0,
+            "type": "UPSCALE_MODEL"
+          },
+          {
+            "id": 1240,
+            "origin_id": 974,
+            "origin_slot": 0,
+            "target_id": 976,
+            "target_slot": 0,
+            "type": "IMAGE"
+          },
+          {
+            "id": 1239,
+            "origin_id": 975,
+            "origin_slot": 0,
+            "target_id": 976,
+            "target_slot": 2,
+            "type": "INT"
+          },
+          {
+            "id": 1238,
+            "origin_id": 975,
+            "origin_slot": 1,
+            "target_id": 976,
+            "target_slot": 3,
+            "type": "INT"
+          },
+          {
+            "id": 1241,
+            "origin_id": 976,
+            "origin_slot": 0,
+            "target_id": 973,
+            "target_slot": 0,
+            "type": "IMAGE"
+          },
+          {
+            "id": 1237,
+            "origin_id": -10,
+            "origin_slot": 0,
+            "target_id": 975,
+            "target_slot": 0,
+            "type": "IMAGE"
+          },
+          {
+            "id": 1236,
+            "origin_id": -10,
+            "origin_slot": 0,
+            "target_id": 974,
+            "target_slot": 1,
+            "type": "IMAGE"
+          },
+          {
+            "id": 1242,
+            "origin_id": 973,
+            "origin_slot": 0,
+            "target_id": -20,
+            "target_slot": 0,
+            "type": "IMAGE"
+          }
+        ],
+        "extra": {
+          "ue_links": [],
+          "links_added_by_ue": []
+        }
+      }
+    ]
+  },
+  "config": {},
+  "extra": {
+    "ds": {
+      "scale": 0.5644739300537776,
+      "offset": [
+        2979.6219773485245,
+        -702.2048007636326
+      ]
+    },
+    "groupNodes": {},
+    "workspace_info": {
+      "id": "hSBfPb8KVVUoyCyWT3oHM"
+    },
+    "node_versions": {
+      "ComfyUI-Frame-Interpolation": "c336f7184cb1ac1243381e725fea1ad2c0a10c09",
+      "ComfyUI-VideoHelperSuite": "8629188458dc6cb832f871ece3bd273507e8a766",
+      "comfy-core": "0.3.15",
+      "ComfyUI_essentials": "33ff89fd354d8ec3ab6affb605a79a931b445d99",
+      "was-node-suite-comfyui": "2afeeeb7d17198cb5a84ed33c4634fe5d171d152",
+      "ComfyLiterals": "bdddb08ca82d90d75d97b1d437a652e0284a32ac",
+      "ComfyUI-Easy-Use": "123917da9adec0d2b0b5f817deefb9ac3ed464f1",
+      "ComfyUI-Impact-Pack": "1ae7cae2df8cca06027edfa3a24512671239d6c4",
+      "ComfyUI-WanVideoWrapper": "44c5944f7031949440315038e94ca3f46e80adb2",
+      "cg-use-everywhere": "ce510b97d10e69d5fd0042e115ecd946890d2079"
+    },
+    "ue_links": [],
+    "VHS_latentpreview": true,
+    "VHS_latentpreviewrate": 0,
+    "VHS_MetadataImage": true,
+    "VHS_KeepIntermediate": true,
+    "links_added_by_ue": [],
+    "frontendVersion": "1.44.19"
+  },
+  "version": 0.4
+}

--- a/workflows/Wan 2.2/Video Generation/SVI 4-pass/Wan2.2_SVI_4pass_V3.json
+++ b/workflows/Wan 2.2/Video Generation/SVI 4-pass/Wan2.2_SVI_4pass_V3.json
@@ -1,0 +1,12858 @@
+{
+  "id": "5a452388-8c0c-42ad-8122-907a29bf650b",
+  "revision": 0,
+  "last_node_id": 1151,
+  "last_link_id": 1529,
+  "nodes": [
+    {
+      "id": 146,
+      "type": "GetNode",
+      "pos": [
+        81.5519503557081,
+        -974.5403859514744
+      ],
+      "size": [
+        210,
+        60
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 0,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "LATENT",
+          "type": "LATENT",
+          "links": [
+            1223
+          ]
+        }
+      ],
+      "title": "Get_anchor sample",
+      "properties": {
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "anchor sample"
+      ],
+      "color": "#323",
+      "bgcolor": "#535"
+    },
+    {
+      "id": 131,
+      "type": "GetNode",
+      "pos": [
+        -215.4477898059265,
+        -1176.870988486821
+      ],
+      "size": [
+        210,
+        58
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 1,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "VAE",
+          "type": "VAE",
+          "links": [
+            1022
+          ]
+        }
+      ],
+      "title": "Get_load vae",
+      "properties": {
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "load vae"
+      ],
+      "color": "#322",
+      "bgcolor": "#533"
+    },
+    {
+      "id": 145,
+      "type": "SetNode",
+      "pos": [
+        -186.8328288684262,
+        -1033.7743087993213
+      ],
+      "size": [
+        210,
+        60
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 97,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "LATENT",
+          "type": "LATENT",
+          "link": 1023
+        }
+      ],
+      "outputs": [
+        {
+          "name": "*",
+          "type": "*",
+          "links": null
+        }
+      ],
+      "title": "Set_anchor sample",
+      "properties": {
+        "previousName": "anchor sample",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "anchor sample"
+      ],
+      "color": "#323",
+      "bgcolor": "#535"
+    },
+    {
+      "id": 354,
+      "type": "SetNode",
+      "pos": [
+        -3083.0821422888703,
+        -133.30277285458993
+      ],
+      "size": [
+        210,
+        34
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 73,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "CLIP",
+          "type": "CLIP",
+          "link": 1003
+        }
+      ],
+      "outputs": [
+        {
+          "name": "*",
+          "type": "*",
+          "links": null
+        }
+      ],
+      "title": "Set_load clip",
+      "properties": {
+        "previousName": "load clip",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "load clip"
+      ],
+      "color": "#432",
+      "bgcolor": "#653"
+    },
+    {
+      "id": 352,
+      "type": "SetNode",
+      "pos": [
+        -3202.56964228887,
+        6.001016207910151
+      ],
+      "size": [
+        210,
+        34
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 70,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "VAE",
+          "type": "VAE",
+          "link": 1004
+        }
+      ],
+      "outputs": [
+        {
+          "name": "*",
+          "type": "*",
+          "links": null
+        }
+      ],
+      "title": "Set_load vae",
+      "properties": {
+        "previousName": "load vae",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "load vae"
+      ],
+      "color": "#322",
+      "bgcolor": "#533"
+    },
+    {
+      "id": 225,
+      "type": "VAELoader",
+      "pos": [
+        -3461.98710322637,
+        -15.05109316708993
+      ],
+      "size": [
+        210,
+        58
+      ],
+      "flags": {
+        "collapsed": false
+      },
+      "order": 2,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "VAE",
+          "type": "VAE",
+          "slot_index": 0,
+          "links": [
+            1004
+          ]
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.3.45",
+        "Node name for S&R": "VAELoader",
+        "models": [
+          {
+            "name": "wan_2.1_vae.safetensors",
+            "url": "https://huggingface.co/Comfy-Org/Wan_2.2_ComfyUI_Repackaged/resolve/main/split_files/vae/wan_2.1_vae.safetensors",
+            "directory": "vae"
+          }
+        ],
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "wan_2.1_vae.safetensors"
+      ],
+      "color": "#223",
+      "bgcolor": "#335"
+    },
+    {
+      "id": 130,
+      "type": "GetNode",
+      "pos": [
+        82.8195284807081,
+        -929.943120326475
+      ],
+      "size": [
+        210,
+        60
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 3,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "VAE",
+          "type": "VAE",
+          "links": [
+            1219
+          ]
+        }
+      ],
+      "title": "Get_load vae",
+      "properties": {
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "load vae"
+      ],
+      "color": "#322",
+      "bgcolor": "#533"
+    },
+    {
+      "id": 316,
+      "type": "GetNode",
+      "pos": [
+        81.68515348070818,
+        -882.3380422014749
+      ],
+      "size": [
+        232.7076171875,
+        60
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 4,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "FLOAT",
+          "type": "FLOAT",
+          "links": []
+        }
+      ],
+      "title": "Get_cfg ksampler nolightning",
+      "properties": {
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "cfg ksampler nolightning"
+      ],
+      "color": "#232",
+      "bgcolor": "#353"
+    },
+    {
+      "id": 197,
+      "type": "GetNode",
+      "pos": [
+        80.32665357314602,
+        -187.17635226087233
+      ],
+      "size": [
+        210,
+        58
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 5,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "VAE",
+          "type": "VAE",
+          "links": [
+            1205
+          ]
+        }
+      ],
+      "title": "Get_load vae",
+      "properties": {
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "load vae"
+      ],
+      "color": "#322",
+      "bgcolor": "#533"
+    },
+    {
+      "id": 891,
+      "type": "CLIPTextEncode",
+      "pos": [
+        -938.0168763572229,
+        117.88321851008072
+      ],
+      "size": [
+        274.03007651084715,
+        125.89909188076172
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 89,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": 1015
+        },
+        {
+          "name": "text",
+          "type": "STRING",
+          "widget": {
+            "name": "text"
+          },
+          "link": 1160
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "slot_index": 0,
+          "links": [
+            1162
+          ]
+        }
+      ],
+      "title": "Positive Prompt",
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.3.45",
+        "Node name for S&R": "CLIPTextEncode",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "She drops her towel, she squeezes her breasts with both hands and moans, her finger are feminine and delicate with bright red nails"
+      ],
+      "color": "#232",
+      "bgcolor": "#353"
+    },
+    {
+      "id": 952,
+      "type": "SetNode",
+      "pos": [
+        -732.2171517850412,
+        116.60840393808735
+      ],
+      "size": [
+        210,
+        60
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 112,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "link": 1162
+        }
+      ],
+      "outputs": [
+        {
+          "name": "*",
+          "type": "*",
+          "links": null
+        }
+      ],
+      "title": "Set_pos_prompt",
+      "properties": {
+        "previousName": "pos_prompt",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "pos_prompt"
+      ],
+      "color": "#332922",
+      "bgcolor": "#593930"
+    },
+    {
+      "id": 892,
+      "type": "CLIPTextEncode",
+      "pos": [
+        -695.1099152238907,
+        210.19686844754244
+      ],
+      "size": [
+        327.2152585843121,
+        124.36420402003517
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 71,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": 1016
+        },
+        {
+          "name": "text",
+          "type": "STRING",
+          "widget": {
+            "name": "text"
+          },
+          "link": 1161
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "slot_index": 0,
+          "links": [
+            1163
+          ]
+        }
+      ],
+      "title": "Negative Prompt",
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.3.45",
+        "Node name for S&R": "CLIPTextEncode",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "色调艳丽，过曝，静态，细节模糊不清，字幕，风格，作品，画作，画面，静止，整体发灰，最差质量，低质量，JPEG压缩残留，丑陋的，残缺的，多余的手指，画得不好的手部，画得不好的脸部，畸形的，毁容的，形态畸形的肢体，手指融合，静止不动的画面，杂乱的背景，三条腿，背景人很多，倒着走"
+      ],
+      "color": "#322",
+      "bgcolor": "#533"
+    },
+    {
+      "id": 961,
+      "type": "GetNode",
+      "pos": [
+        83.42894955189686,
+        -790.3517077621615
+      ],
+      "size": [
+        210,
+        34
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 6,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": [
+            1222
+          ]
+        }
+      ],
+      "title": "Get_neg_prompt",
+      "properties": {
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "neg_prompt"
+      ],
+      "color": "#332922",
+      "bgcolor": "#593930"
+    },
+    {
+      "id": 969,
+      "type": "GetNode",
+      "pos": [
+        87.49449530217929,
+        -748.0797488086223
+      ],
+      "size": [
+        210,
+        34
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 7,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "INT",
+          "type": "INT",
+          "links": [
+            1232
+          ]
+        }
+      ],
+      "title": "Get_seg_length",
+      "properties": {
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "seg_length"
+      ],
+      "color": "#1b4669",
+      "bgcolor": "#29699c"
+    },
+    {
+      "id": 951,
+      "type": "PrimitiveStringMultiline",
+      "pos": [
+        -588.0060502027982,
+        175.40979570499994
+      ],
+      "size": [
+        400,
+        200.33897210743794
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 8,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "STRING",
+          "type": "STRING",
+          "links": [
+            1161
+          ]
+        }
+      ],
+      "title": "Negative Prompt",
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.22.0",
+        "Node name for S&R": "PrimitiveStringMultiline",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "input_ue_unconnectable": {},
+          "version": "7.8"
+        }
+      },
+      "widgets_values": [
+        "色调艳丽，过曝，静态，细节模糊不清，字幕，风格，作品，画作，画面，静止，整体发灰，最差质量，低质量，JPEG压缩残留，丑陋的，残缺的，多余的手指，画得不好的手部，画得不好的脸部，畸形的，毁容的，形态畸形的肢体，手指融合，静止不动的画面，杂乱的背景，三条腿，背景人很多，倒着走"
+      ],
+      "color": "#322",
+      "bgcolor": "#533"
+    },
+    {
+      "id": 998,
+      "type": "SetNode",
+      "pos": [
+        -221.14310462620435,
+        115.94680240356809
+      ],
+      "size": [
+        210,
+        50
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 113,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "link": 1276
+        }
+      ],
+      "outputs": [
+        {
+          "name": "*",
+          "type": "*",
+          "links": null
+        }
+      ],
+      "title": "Set_pos_2",
+      "properties": {
+        "previousName": "pos_2",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "pos_2"
+      ],
+      "color": "#332922",
+      "bgcolor": "#593930"
+    },
+    {
+      "id": 993,
+      "type": "CLIPTextEncode",
+      "pos": [
+        -456.0904582505366,
+        116.0127968346487
+      ],
+      "size": [
+        274.03007651084715,
+        125.89909188076172
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 90,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": 1277
+        },
+        {
+          "name": "text",
+          "type": "STRING",
+          "widget": {
+            "name": "text"
+          },
+          "link": 1272
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "slot_index": 0,
+          "links": [
+            1276
+          ]
+        }
+      ],
+      "title": "Positive Prompt",
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.3.45",
+        "Node name for S&R": "CLIPTextEncode",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "She drops her towel, she squeezes her breasts with both hands and moans, her finger are feminine and delicate with bright red nails"
+      ],
+      "color": "#232",
+      "bgcolor": "#353"
+    },
+    {
+      "id": 137,
+      "type": "GetNode",
+      "pos": [
+        -580.8490082183074,
+        -184.62103098086075
+      ],
+      "size": [
+        210,
+        58
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 9,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "CLIP",
+          "type": "CLIP",
+          "links": [
+            1015,
+            1016,
+            1277,
+            1438,
+            1439
+          ]
+        }
+      ],
+      "title": "Get_load clip",
+      "properties": {
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "load clip"
+      ],
+      "color": "#432",
+      "bgcolor": "#653"
+    },
+    {
+      "id": 896,
+      "type": "VAEEncode",
+      "pos": [
+        -203.9436101184264,
+        -1123.2752853618208
+      ],
+      "size": [
+        191.30234375,
+        46
+      ],
+      "flags": {
+        "collapsed": false
+      },
+      "order": 72,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "pixels",
+          "type": "IMAGE",
+          "link": 1021
+        },
+        {
+          "name": "vae",
+          "type": "VAE",
+          "link": 1022
+        }
+      ],
+      "outputs": [
+        {
+          "name": "LATENT",
+          "type": "LATENT",
+          "links": [
+            1023
+          ]
+        }
+      ],
+      "title": "Encode anchor sample",
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.5.1",
+        "Node name for S&R": "VAEEncode",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.0.1",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [],
+      "color": "#322",
+      "bgcolor": "#533"
+    },
+    {
+      "id": 139,
+      "type": "GetNode",
+      "pos": [
+        -226.49376636842658,
+        -1225.8463400493213
+      ],
+      "size": [
+        269.6763671875,
+        60
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 10,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": [
+            1021
+          ]
+        }
+      ],
+      "title": "Get_load image (perfectresolution)",
+      "properties": {
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "load image (perfectresolution)"
+      ],
+      "color": "#2a363b",
+      "bgcolor": "#3f5159"
+    },
+    {
+      "id": 138,
+      "type": "SetNode",
+      "pos": [
+        -220.59130543092647,
+        -1273.061105674321
+      ],
+      "size": [
+        268.2134765625,
+        58
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 120,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "link": 1014
+        }
+      ],
+      "outputs": [
+        {
+          "name": "*",
+          "type": "*",
+          "links": null
+        }
+      ],
+      "title": "Set_load image (perfectresolution)",
+      "properties": {
+        "previousName": "load image (perfectresolution)",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "load image (perfectresolution)"
+      ],
+      "color": "#2a363b",
+      "bgcolor": "#3f5159"
+    },
+    {
+      "id": 880,
+      "type": "ModelSamplingSD3",
+      "pos": [
+        -2712.3108746841885,
+        -587.0180385350592
+      ],
+      "size": [
+        210,
+        50
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 106,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "model",
+          "type": "MODEL",
+          "link": 1474
+        },
+        {
+          "name": "shift",
+          "type": "FLOAT",
+          "widget": {
+            "name": "shift"
+          },
+          "link": 1292
+        }
+      ],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "slot_index": 0,
+          "links": [
+            1006
+          ]
+        }
+      ],
+      "title": "High model shift",
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.3.45",
+        "Node name for S&R": "ModelSamplingSD3",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.1",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        5
+      ],
+      "color": "#223",
+      "bgcolor": "#335"
+    },
+    {
+      "id": 200,
+      "type": "GetNode",
+      "pos": [
+        79.56884107314602,
+        -229.9497897608722
+      ],
+      "size": [
+        210,
+        58
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 11,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "LATENT",
+          "type": "LATENT",
+          "links": [
+            1209
+          ]
+        }
+      ],
+      "title": "Get_anchor sample",
+      "properties": {
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "anchor sample"
+      ],
+      "color": "#323",
+      "bgcolor": "#535"
+    },
+    {
+      "id": 955,
+      "type": "GetNode",
+      "pos": [
+        82.15090819436486,
+        -834.6683300151667
+      ],
+      "size": [
+        210,
+        58
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 12,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": [
+            1221
+          ]
+        }
+      ],
+      "title": "Get_pos_prompt",
+      "properties": {
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "pos_prompt"
+      ],
+      "color": "#332922",
+      "bgcolor": "#593930"
+    },
+    {
+      "id": 968,
+      "type": "GetNode",
+      "pos": [
+        92.4087406416801,
+        -52.70025999616909
+      ],
+      "size": [
+        210,
+        60
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 13,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "INT",
+          "type": "INT",
+          "links": [
+            1356
+          ]
+        }
+      ],
+      "title": "Get_seg_length",
+      "properties": {
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "seg_length"
+      ],
+      "color": "#1b4669",
+      "bgcolor": "#29699c"
+    },
+    {
+      "id": 1015,
+      "type": "GetNode",
+      "pos": [
+        81.78355791725903,
+        -536.6149544307951
+      ],
+      "size": [
+        210,
+        60
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 14,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "SIGMAS",
+          "type": "SIGMAS",
+          "links": [
+            1352,
+            1354
+          ]
+        }
+      ],
+      "title": "Get_sigmas_high",
+      "properties": {
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "sigmas_high"
+      ],
+      "color": "#485248",
+      "bgcolor": "#272e27"
+    },
+    {
+      "id": 1016,
+      "type": "GetNode",
+      "pos": [
+        88.14840037593672,
+        -493.221034944742
+      ],
+      "size": [
+        210,
+        58
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 15,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "SIGMAS",
+          "type": "SIGMAS",
+          "links": [
+            1353,
+            1355
+          ]
+        }
+      ],
+      "title": "Get_sigmas_low",
+      "properties": {
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "sigmas_low"
+      ],
+      "color": "#485248",
+      "bgcolor": "#272e27"
+    },
+    {
+      "id": 954,
+      "type": "GetNode",
+      "pos": [
+        96.65515048164899,
+        -141.18970139946438
+      ],
+      "size": [
+        210,
+        60
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 16,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": [
+            1207
+          ]
+        }
+      ],
+      "title": "Get_pos_2",
+      "properties": {
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "pos_2"
+      ],
+      "color": "#332922",
+      "bgcolor": "#593930"
+    },
+    {
+      "id": 960,
+      "type": "GetNode",
+      "pos": [
+        88.31140048164919,
+        -97.37290452446454
+      ],
+      "size": [
+        210,
+        34
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 17,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": [
+            1208
+          ]
+        }
+      ],
+      "title": "Get_neg_prompt",
+      "properties": {
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "neg_prompt"
+      ],
+      "color": "#332922",
+      "bgcolor": "#593930"
+    },
+    {
+      "id": 224,
+      "type": "CLIPLoader",
+      "pos": [
+        -3474.934759476371,
+        -167.95238222958994
+      ],
+      "size": [
+        346.391845703125,
+        106
+      ],
+      "flags": {},
+      "order": 18,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "CLIP",
+          "type": "CLIP",
+          "slot_index": 0,
+          "links": [
+            1003
+          ]
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.3.45",
+        "Node name for S&R": "CLIPLoader",
+        "models": [
+          {
+            "name": "umt5_xxl_fp8_e4m3fn_scaled.safetensors",
+            "url": "https://huggingface.co/Comfy-Org/Wan_2.1_ComfyUI_repackaged/resolve/main/split_files/text_encoders/umt5_xxl_fp8_e4m3fn_scaled.safetensors",
+            "directory": "text_encoders"
+          }
+        ],
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "umt5_xxl_fp8_e4m3fn_scaled.safetensors",
+        "wan",
+        "default"
+      ],
+      "color": "#223",
+      "bgcolor": "#335"
+    },
+    {
+      "id": 1004,
+      "type": "ModelSamplingSD3",
+      "pos": [
+        -2745.397819318747,
+        -250.39431681501756
+      ],
+      "size": [
+        210,
+        58
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 84,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "model",
+          "type": "MODEL",
+          "link": 1475
+        }
+      ],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "slot_index": 0,
+          "links": [
+            1290
+          ]
+        }
+      ],
+      "title": "Low model shift",
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.3.45",
+        "Node name for S&R": "ModelSamplingSD3",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.1",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        5
+      ],
+      "color": "#223",
+      "bgcolor": "#335"
+    },
+    {
+      "id": 1014,
+      "type": "SetNode",
+      "pos": [
+        -3132.309640253585,
+        -231.60943583393865
+      ],
+      "size": [
+        210,
+        58
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 108,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "SIGMAS",
+          "type": "SIGMAS",
+          "link": 1351
+        }
+      ],
+      "outputs": [
+        {
+          "name": "*",
+          "type": "*",
+          "links": null
+        }
+      ],
+      "title": "Set_sigmas_low",
+      "properties": {
+        "previousName": "sigmas_low",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "sigmas_low"
+      ],
+      "color": "#485248",
+      "bgcolor": "#272e27"
+    },
+    {
+      "id": 1013,
+      "type": "SetNode",
+      "pos": [
+        -2955.3756626257436,
+        -234.0829922970069
+      ],
+      "size": [
+        210,
+        60
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 107,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "SIGMAS",
+          "type": "SIGMAS",
+          "link": 1350
+        }
+      ],
+      "outputs": [
+        {
+          "name": "*",
+          "type": "*",
+          "links": null
+        }
+      ],
+      "title": "Set_sigmas_high",
+      "properties": {
+        "previousName": "sigmas_high",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "sigmas_high"
+      ],
+      "color": "#485248",
+      "bgcolor": "#272e27"
+    },
+    {
+      "id": 357,
+      "type": "SetNode",
+      "pos": [
+        -2675.0801983541246,
+        50.76307200213164
+      ],
+      "size": [
+        241.6080078125,
+        49.99999999999999
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 122,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "link": 1012
+        }
+      ],
+      "outputs": [
+        {
+          "name": "*",
+          "type": "*",
+          "links": null
+        }
+      ],
+      "title": "Set_low_model",
+      "properties": {
+        "previousName": "low_model",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "low_model"
+      ],
+      "color": "#223",
+      "bgcolor": "#335"
+    },
+    {
+      "id": 358,
+      "type": "SetNode",
+      "pos": [
+        -2562.3715278350105,
+        -250.4964225919242
+      ],
+      "size": [
+        241.6080078125,
+        50
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 125,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "link": 1009
+        }
+      ],
+      "outputs": [
+        {
+          "name": "*",
+          "type": "*",
+          "links": null
+        }
+      ],
+      "title": "Set_high_model",
+      "properties": {
+        "previousName": "high_model",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "high_model"
+      ],
+      "color": "#223",
+      "bgcolor": "#335"
+    },
+    {
+      "id": 1026,
+      "type": "SetNode",
+      "pos": [
+        -2126.138599020979,
+        -291.4716156582535
+      ],
+      "size": [
+        210,
+        58
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 98,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "link": 1381
+        }
+      ],
+      "outputs": [
+        {
+          "name": "*",
+          "type": "*",
+          "links": null
+        }
+      ],
+      "title": "Set_SEG1_LowModel",
+      "properties": {
+        "previousName": "SEG1_LowModel",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "SEG1_LowModel"
+      ],
+      "color": "#223",
+      "bgcolor": "#335"
+    },
+    {
+      "id": 411,
+      "type": "GetNode",
+      "pos": [
+        82.99864157706429,
+        -1055.8717731632767
+      ],
+      "size": [
+        225.9947265625,
+        60.92295998177042
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 19,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": [
+            1217
+          ]
+        }
+      ],
+      "title": "Get_SEG1_HighModel",
+      "properties": {
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "SEG1_HighModel"
+      ],
+      "color": "#223",
+      "bgcolor": "#335"
+    },
+    {
+      "id": 412,
+      "type": "GetNode",
+      "pos": [
+        79.26516501456423,
+        -1015.3464845233913
+      ],
+      "size": [
+        220.45078125,
+        60.92295998177042
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 20,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": [
+            1220
+          ]
+        }
+      ],
+      "title": "Get_SEG1_LowModel",
+      "properties": {
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "SEG1_LowModel"
+      ],
+      "color": "#223",
+      "bgcolor": "#335"
+    },
+    {
+      "id": 1025,
+      "type": "SetNode",
+      "pos": [
+        -2122.400155445895,
+        -602.1450614051075
+      ],
+      "size": [
+        210,
+        60
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 100,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "link": 1382
+        }
+      ],
+      "outputs": [
+        {
+          "name": "*",
+          "type": "*",
+          "links": null
+        }
+      ],
+      "title": "Set_SEG1_HighModel",
+      "properties": {
+        "previousName": "SEG1_HighModel",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "SEG1_HighModel"
+      ],
+      "color": "#223",
+      "bgcolor": "#335"
+    },
+    {
+      "id": 1027,
+      "type": "SetNode",
+      "pos": [
+        -1362.777545301969,
+        -609.5157084456328
+      ],
+      "size": [
+        210,
+        58
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 103,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "link": 1383
+        }
+      ],
+      "outputs": [
+        {
+          "name": "*",
+          "type": "*",
+          "links": null
+        }
+      ],
+      "title": "Set_SEG2_HighModel",
+      "properties": {
+        "previousName": "SEG2_HighModel",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "SEG2_HighModel"
+      ],
+      "color": "#223",
+      "bgcolor": "#335"
+    },
+    {
+      "id": 1028,
+      "type": "SetNode",
+      "pos": [
+        -1359.4097825765743,
+        -306.42350509758484
+      ],
+      "size": [
+        210,
+        58
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 105,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "link": 1384
+        }
+      ],
+      "outputs": [
+        {
+          "name": "*",
+          "type": "*",
+          "links": null
+        }
+      ],
+      "title": "Set_SEG2_LowModel",
+      "properties": {
+        "previousName": "SEG2_LowModel",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "SEG2_LowModel"
+      ],
+      "color": "#223",
+      "bgcolor": "#335"
+    },
+    {
+      "id": 1032,
+      "type": "GetNode",
+      "pos": [
+        78.61842246859956,
+        -271.1498296308949
+      ],
+      "size": [
+        210,
+        50
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 21,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": [
+            1390
+          ]
+        }
+      ],
+      "title": "Get_SEG2_LowModel",
+      "properties": {
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "SEG2_LowModel"
+      ],
+      "color": "#223",
+      "bgcolor": "#335"
+    },
+    {
+      "id": 1048,
+      "type": "SetNode",
+      "pos": [
+        -207.80876610853326,
+        524.3185576969647
+      ],
+      "size": [
+        210,
+        34
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 115,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "link": 1396
+        }
+      ],
+      "outputs": [
+        {
+          "name": "*",
+          "type": "*",
+          "links": null
+        }
+      ],
+      "title": "Set_pos_4",
+      "properties": {
+        "previousName": "",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "pos_4"
+      ],
+      "color": "#332922",
+      "bgcolor": "#593930"
+    },
+    {
+      "id": 1058,
+      "type": "GetNode",
+      "pos": [
+        103.99583910227543,
+        301.3066011872588
+      ],
+      "size": [
+        210,
+        34
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 22,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "VAE",
+          "type": "VAE",
+          "links": [
+            1397
+          ]
+        }
+      ],
+      "title": "Get_load vae",
+      "properties": {
+        "Node name for S&R": "GetNode",
+        "aux_id": "kijai/ComfyUI-KJNodes",
+        "previousName": "load vae",
+        "ue_properties": {
+          "version": "7.8",
+          "widget_ue_connectable": {},
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "load vae"
+      ],
+      "color": "#322",
+      "bgcolor": "#533"
+    },
+    {
+      "id": 1069,
+      "type": "GetNode",
+      "pos": [
+        110.00598771891958,
+        1029.8292317438338
+      ],
+      "size": [
+        210,
+        34
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 23,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": [
+            1409
+          ]
+        }
+      ],
+      "title": "Get_neg_prompt",
+      "properties": {
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "neg_prompt"
+      ],
+      "color": "#332922",
+      "bgcolor": "#593930"
+    },
+    {
+      "id": 1071,
+      "type": "GetNode",
+      "pos": [
+        114.92261843705649,
+        392.341504131516
+      ],
+      "size": [
+        210,
+        34
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 24,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": [
+            1400
+          ]
+        }
+      ],
+      "title": "Get_neg_prompt",
+      "properties": {
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "neg_prompt"
+      ],
+      "color": "#332922",
+      "bgcolor": "#593930"
+    },
+    {
+      "id": 1072,
+      "type": "GetNode",
+      "pos": [
+        116.13267864427911,
+        432.90401717972117
+      ],
+      "size": [
+        210,
+        34
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 25,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "INT",
+          "type": "INT",
+          "links": [
+            1401
+          ]
+        }
+      ],
+      "title": "Get_seg_length",
+      "properties": {
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "seg_length"
+      ],
+      "color": "#1b4669",
+      "bgcolor": "#29699c"
+    },
+    {
+      "id": 1073,
+      "type": "GetNode",
+      "pos": [
+        111.60173427411557,
+        1074.0154950126712
+      ],
+      "size": [
+        210,
+        34
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 26,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "INT",
+          "type": "INT",
+          "links": [
+            1410
+          ]
+        }
+      ],
+      "title": "Get_seg_length",
+      "properties": {
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "seg_length"
+      ],
+      "color": "#1b4669",
+      "bgcolor": "#29699c"
+    },
+    {
+      "id": 1076,
+      "type": "GetNode",
+      "pos": [
+        104.6520814689195,
+        987.169856743833
+      ],
+      "size": [
+        210,
+        34
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 27,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": [
+            1408
+          ]
+        }
+      ],
+      "title": "Get_pos_4",
+      "properties": {
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "pos_4"
+      ],
+      "color": "#332922",
+      "bgcolor": "#593930"
+    },
+    {
+      "id": 1074,
+      "type": "GetNode",
+      "pos": [
+        118.49376450367748,
+        1117.9112069814432
+      ],
+      "size": [
+        210,
+        34
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 28,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "INT",
+          "type": "INT",
+          "links": [
+            1411
+          ]
+        }
+      ],
+      "title": "Get_seed",
+      "properties": {
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "seed"
+      ],
+      "color": "#1b4669",
+      "bgcolor": "#29699c"
+    },
+    {
+      "id": 1067,
+      "type": "GetNode",
+      "pos": [
+        100.60582119738258,
+        847.4009554053491
+      ],
+      "size": [
+        210,
+        34
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 29,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "VAE",
+          "type": "VAE",
+          "links": [
+            1407
+          ]
+        }
+      ],
+      "title": "Get_load vae",
+      "properties": {
+        "Node name for S&R": "GetNode",
+        "aux_id": "kijai/ComfyUI-KJNodes",
+        "previousName": "load vae",
+        "ue_properties": {
+          "version": "7.8",
+          "widget_ue_connectable": {},
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "load vae"
+      ],
+      "color": "#322",
+      "bgcolor": "#533"
+    },
+    {
+      "id": 1084,
+      "type": "SetNode",
+      "pos": [
+        -2104.8092452391493,
+        446.85306428756326
+      ],
+      "size": [
+        210,
+        50
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 99,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "link": 1413
+        }
+      ],
+      "outputs": [
+        {
+          "name": "*",
+          "type": "*",
+          "links": null
+        }
+      ],
+      "title": "Set_SEG3_LowModel",
+      "properties": {
+        "previousName": "SEG3_LowModel",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "SEG3_LowModel"
+      ],
+      "color": "#223",
+      "bgcolor": "#335"
+    },
+    {
+      "id": 1088,
+      "type": "SetNode",
+      "pos": [
+        -1352.512718507376,
+        459.1000496622078
+      ],
+      "size": [
+        210,
+        50
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 104,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "link": 1415
+        }
+      ],
+      "outputs": [
+        {
+          "name": "*",
+          "type": "*",
+          "links": null
+        }
+      ],
+      "title": "Set_SEG4_LowModel",
+      "properties": {
+        "previousName": "SEG4_LowModel",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "SEG4_LowModel"
+      ],
+      "color": "#223",
+      "bgcolor": "#335"
+    },
+    {
+      "id": 1089,
+      "type": "SetNode",
+      "pos": [
+        -1360.2903104756679,
+        115.54953794077406
+      ],
+      "size": [
+        210,
+        50.000000000000014
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 102,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "link": 1414
+        }
+      ],
+      "outputs": [
+        {
+          "name": "*",
+          "type": "*",
+          "links": null
+        }
+      ],
+      "title": "Set_SEG4_HighModel",
+      "properties": {
+        "previousName": "SEG4_HighModel",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "SEG4_HighModel"
+      ],
+      "color": "#223",
+      "bgcolor": "#335"
+    },
+    {
+      "id": 1029,
+      "type": "GetNode",
+      "pos": [
+        -2050.2867989176707,
+        -204.05826588012695
+      ],
+      "size": [
+        210,
+        60
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 30,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": [
+            1386,
+            1417
+          ]
+        }
+      ],
+      "title": "Get_low_model",
+      "properties": {
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "low_model"
+      ],
+      "color": "#223",
+      "bgcolor": "#335"
+    },
+    {
+      "id": 1064,
+      "type": "GetNode",
+      "pos": [
+        90.9261873003562,
+        938.0836199150474
+      ],
+      "size": [
+        220.45078125,
+        50
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 31,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": [
+            1425
+          ]
+        }
+      ],
+      "title": "Get_SEG4_LowModel",
+      "properties": {
+        "Node name for S&R": "GetNode",
+        "aux_id": "kijai/ComfyUI-KJNodes",
+        "previousName": "svi model lightning low",
+        "ue_properties": {
+          "version": "7.8",
+          "widget_ue_connectable": {},
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "SEG4_LowModel"
+      ],
+      "color": "#223",
+      "bgcolor": "#335"
+    },
+    {
+      "id": 1080,
+      "type": "GetNode",
+      "pos": [
+        89.09664924071149,
+        897.1609617599456
+      ],
+      "size": [
+        220.45078125,
+        50
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 32,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": [
+            1424
+          ]
+        }
+      ],
+      "title": "Get_SEG4_HighModel",
+      "properties": {
+        "Node name for S&R": "GetNode",
+        "aux_id": "kijai/ComfyUI-KJNodes",
+        "previousName": "svi model lightning low",
+        "ue_properties": {
+          "version": "7.8",
+          "widget_ue_connectable": {},
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "SEG4_HighModel"
+      ],
+      "color": "#223",
+      "bgcolor": "#335"
+    },
+    {
+      "id": 1068,
+      "type": "GetNode",
+      "pos": [
+        100.23650301556442,
+        805.1929085196664
+      ],
+      "size": [
+        210,
+        34
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 33,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "LATENT",
+          "type": "LATENT",
+          "links": [
+            1406
+          ]
+        }
+      ],
+      "title": "Get_anchor sample",
+      "properties": {
+        "Node name for S&R": "GetNode",
+        "aux_id": "kijai/ComfyUI-KJNodes",
+        "previousName": "anchor sample",
+        "ue_properties": {
+          "version": "7.8",
+          "widget_ue_connectable": {},
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "anchor sample"
+      ],
+      "color": "#323",
+      "bgcolor": "#535"
+    },
+    {
+      "id": 1077,
+      "type": "GetNode",
+      "pos": [
+        120.46267565490186,
+        473.3862365505442
+      ],
+      "size": [
+        210,
+        34
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 34,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "INT",
+          "type": "INT",
+          "links": [
+            1402
+          ]
+        }
+      ],
+      "title": "Get_seed",
+      "properties": {
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "seed"
+      ],
+      "color": "#1b4669",
+      "bgcolor": "#29699c"
+    },
+    {
+      "id": 1093,
+      "type": "GetNode",
+      "pos": [
+        119.53707440323342,
+        661.6710934536369
+      ],
+      "size": [
+        210,
+        34
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 35,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "SIGMAS",
+          "type": "SIGMAS",
+          "links": [
+            1427,
+            1429
+          ]
+        }
+      ],
+      "title": "Get_sigmas_low",
+      "properties": {
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "sigmas_low"
+      ],
+      "color": "#485248",
+      "bgcolor": "#272e27"
+    },
+    {
+      "id": 906,
+      "type": "ImageBatchExtendWithOverlap",
+      "pos": [
+        801.5392583468272,
+        -632.8127780211989
+      ],
+      "size": [
+        321.6236328125,
+        146
+      ],
+      "flags": {},
+      "order": 118,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "source_images",
+          "type": "IMAGE",
+          "link": 1224
+        },
+        {
+          "name": "new_images",
+          "shape": 7,
+          "type": "IMAGE",
+          "link": 1211
+        }
+      ],
+      "outputs": [
+        {
+          "name": "source_images",
+          "type": "IMAGE",
+          "links": []
+        },
+        {
+          "name": "start_images",
+          "type": "IMAGE",
+          "links": []
+        },
+        {
+          "name": "extended_images",
+          "type": "IMAGE",
+          "links": [
+            1432
+          ]
+        }
+      ],
+      "title": "Merge Pass 1 + Pass 2 overlap",
+      "properties": {
+        "cnr_id": "comfyui-kjnodes",
+        "ver": "79f529a84a8c20fe5dcdfa984c6be7a94102c014",
+        "Node name for S&R": "ImageBatchExtendWithOverlap",
+        "aux_id": "kijai/ComfyUI-KJNodes",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        5,
+        "source",
+        "linear_blend"
+      ]
+    },
+    {
+      "id": 953,
+      "type": "SetNode",
+      "pos": [
+        -510.3262185442715,
+        213.48595915705704
+      ],
+      "size": [
+        210,
+        60
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 96,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "link": 1163
+        }
+      ],
+      "outputs": [
+        {
+          "name": "*",
+          "type": "*",
+          "links": null
+        }
+      ],
+      "title": "Set_neg_prompt",
+      "properties": {
+        "previousName": "neg_prompt",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "neg_prompt"
+      ],
+      "color": "#332922",
+      "bgcolor": "#593930"
+    },
+    {
+      "id": 1059,
+      "type": "GetNode",
+      "pos": [
+        103.65759573950098,
+        265.74531936675004
+      ],
+      "size": [
+        210,
+        34
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 36,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "LATENT",
+          "type": "LATENT",
+          "links": [
+            1398
+          ]
+        }
+      ],
+      "title": "Get_anchor sample",
+      "properties": {
+        "Node name for S&R": "GetNode",
+        "aux_id": "kijai/ComfyUI-KJNodes",
+        "previousName": "anchor sample",
+        "ue_properties": {
+          "version": "7.8",
+          "widget_ue_connectable": {},
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "anchor sample"
+      ],
+      "color": "#323",
+      "bgcolor": "#535"
+    },
+    {
+      "id": 1096,
+      "type": "GetNode",
+      "pos": [
+        103.32682884401356,
+        221.90635706918306
+      ],
+      "size": [
+        210.37286931818176,
+        58
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 37,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": [
+            1437
+          ]
+        }
+      ],
+      "title": "Get_SEG3_LowModel",
+      "properties": {
+        "Node name for S&R": "GetNode",
+        "aux_id": "kijai/ComfyUI-KJNodes",
+        "previousName": "svi model lightning low",
+        "ue_properties": {
+          "version": "7.8",
+          "widget_ue_connectable": {},
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "SEG3_LowModel"
+      ],
+      "color": "#223",
+      "bgcolor": "#335"
+    },
+    {
+      "id": 1046,
+      "type": "CLIPTextEncode",
+      "pos": [
+        -409.45268246765085,
+        523.3619905261014
+      ],
+      "size": [
+        274.03007651084715,
+        126.39538094326167
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 92,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": 1438
+        },
+        {
+          "name": "text",
+          "type": "STRING",
+          "widget": {
+            "name": "text"
+          },
+          "link": 1394
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "slot_index": 0,
+          "links": [
+            1396
+          ]
+        }
+      ],
+      "title": "Positive Prompt",
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.3.45",
+        "Node name for S&R": "CLIPTextEncode",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "She drops her towel, she squeezes her breasts with both hands and moans, her finger are feminine and delicate with bright red nails"
+      ],
+      "color": "#232",
+      "bgcolor": "#353"
+    },
+    {
+      "id": 1045,
+      "type": "CLIPTextEncode",
+      "pos": [
+        -922.9959535044654,
+        531.1111674548674
+      ],
+      "size": [
+        274.03007651084715,
+        125.89909188076172
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 91,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": 1439
+        },
+        {
+          "name": "text",
+          "type": "STRING",
+          "widget": {
+            "name": "text"
+          },
+          "link": 1393
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "slot_index": 0,
+          "links": [
+            1395
+          ]
+        }
+      ],
+      "title": "Positive Prompt",
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.3.45",
+        "Node name for S&R": "CLIPTextEncode",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "She drops her towel, she squeezes her breasts with both hands and moans, her finger are feminine and delicate with bright red nails"
+      ],
+      "color": "#232",
+      "bgcolor": "#353"
+    },
+    {
+      "id": 1030,
+      "type": "GetNode",
+      "pos": [
+        -2261.325816997218,
+        -204.2171997309803
+      ],
+      "size": [
+        210,
+        58
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 38,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": [
+            1388,
+            1419
+          ]
+        }
+      ],
+      "title": "Get_high_model",
+      "properties": {
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "high_model"
+      ],
+      "color": "#223",
+      "bgcolor": "#335"
+    },
+    {
+      "id": 1090,
+      "type": "GetNode",
+      "pos": [
+        -1508.5548302204445,
+        -204.932535008247
+      ],
+      "size": [
+        210,
+        50
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 39,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": [
+            1420,
+            1421
+          ]
+        }
+      ],
+      "title": "Get_high_model",
+      "properties": {
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "high_model"
+      ],
+      "color": "#223",
+      "bgcolor": "#335"
+    },
+    {
+      "id": 1091,
+      "type": "GetNode",
+      "pos": [
+        -1228.6888013864213,
+        -207.94618570043963
+      ],
+      "size": [
+        210,
+        50
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 40,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": [
+            1422,
+            1423
+          ]
+        }
+      ],
+      "title": "Get_low_model",
+      "properties": {
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "low_model"
+      ],
+      "color": "#223",
+      "bgcolor": "#335"
+    },
+    {
+      "id": 1081,
+      "type": "SetNode",
+      "pos": [
+        -2107.256753034771,
+        126.4066194296152
+      ],
+      "size": [
+        210,
+        50
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 101,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "link": 1412
+        }
+      ],
+      "outputs": [
+        {
+          "name": "*",
+          "type": "*",
+          "links": null
+        }
+      ],
+      "title": "Set_SEG3_HighModel",
+      "properties": {
+        "previousName": "SEG3_HighModel",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "SEG3_HighModel"
+      ],
+      "color": "#223",
+      "bgcolor": "#335"
+    },
+    {
+      "id": 967,
+      "type": "SetNode",
+      "pos": [
+        -216.72081459913093,
+        -758.6186988155397
+      ],
+      "size": [
+        210,
+        60
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 95,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "INT",
+          "type": "INT",
+          "link": 1230
+        }
+      ],
+      "outputs": [
+        {
+          "name": "*",
+          "type": "*",
+          "links": null
+        }
+      ],
+      "title": "Set_seg_length",
+      "properties": {
+        "previousName": "seg_length",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "seg_length"
+      ],
+      "color": "#1b4669",
+      "bgcolor": "#29699c"
+    },
+    {
+      "id": 1075,
+      "type": "GetNode",
+      "pos": [
+        110.6901965620566,
+        351.166504131516
+      ],
+      "size": [
+        210,
+        50
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 41,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "links": [
+            1399
+          ]
+        }
+      ],
+      "title": "Get_pos_3",
+      "properties": {
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "pos_3"
+      ],
+      "color": "#332922",
+      "bgcolor": "#593930"
+    },
+    {
+      "id": 1047,
+      "type": "SetNode",
+      "pos": [
+        -702.0250508568425,
+        531.2340582604509
+      ],
+      "size": [
+        210,
+        50
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 114,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "CONDITIONING",
+          "type": "CONDITIONING",
+          "link": 1395
+        }
+      ],
+      "outputs": [
+        {
+          "name": "*",
+          "type": "*",
+          "links": null
+        }
+      ],
+      "title": "Set_pos_3",
+      "properties": {
+        "previousName": "",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "pos_3"
+      ],
+      "color": "#332922",
+      "bgcolor": "#593930"
+    },
+    {
+      "id": 984,
+      "type": "Seed (rgthree)",
+      "pos": [
+        -958.7086939637035,
+        -734.1407328302952
+      ],
+      "size": [
+        216.74894531250004,
+        130
+      ],
+      "flags": {},
+      "order": 42,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "dir": 4,
+          "name": "SEED",
+          "shape": 3,
+          "type": "INT",
+          "links": [
+            1263
+          ]
+        }
+      ],
+      "properties": {
+        "cnr_id": "rgthree-comfy",
+        "ver": "738105af5fb14e96fbecaf406dc356e284797e8c",
+        "randomMax": 1125899906842624,
+        "randomMin": 0,
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "input_ue_unconnectable": {},
+          "version": "7.8"
+        }
+      },
+      "widgets_values": [
+        -1,
+        "",
+        "",
+        "okay"
+      ]
+    },
+    {
+      "id": 985,
+      "type": "SetNode",
+      "pos": [
+        -924.7247383206251,
+        -563.2247491655224
+      ],
+      "size": [
+        210,
+        60
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 82,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "INT",
+          "type": "INT",
+          "link": 1263
+        }
+      ],
+      "outputs": [
+        {
+          "name": "*",
+          "type": "*",
+          "links": null
+        }
+      ],
+      "title": "Set_seed",
+      "properties": {
+        "previousName": "seed",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "seed"
+      ],
+      "color": "#1b4669",
+      "bgcolor": "#29699c"
+    },
+    {
+      "id": 887,
+      "type": "ImageResizeKJv2",
+      "pos": [
+        -526.9478824583027,
+        -1281.1484652430192
+      ],
+      "size": [
+        270,
+        336
+      ],
+      "flags": {},
+      "order": 111,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "image",
+          "type": "IMAGE",
+          "link": 1013
+        },
+        {
+          "name": "mask",
+          "shape": 7,
+          "type": "MASK",
+          "link": null
+        },
+        {
+          "name": "width",
+          "type": "INT",
+          "widget": {
+            "name": "width"
+          },
+          "link": 1460
+        },
+        {
+          "name": "height",
+          "type": "INT",
+          "widget": {
+            "name": "height"
+          },
+          "link": 1461
+        }
+      ],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": [
+            1014
+          ]
+        },
+        {
+          "name": "width",
+          "type": "INT",
+          "links": null
+        },
+        {
+          "name": "height",
+          "type": "INT",
+          "links": null
+        },
+        {
+          "name": "mask",
+          "type": "MASK",
+          "links": null
+        }
+      ],
+      "title": "Resize input to SVI resolution",
+      "properties": {
+        "cnr_id": "comfyui-kjnodes",
+        "ver": "204f6d5aae73b10c0fe2fb26e61405fd6337bb77",
+        "Node name for S&R": "ImageResizeKJv2",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "input_ue_unconnectable": {},
+          "version": "7.8"
+        }
+      },
+      "widgets_values": [
+        720,
+        1280,
+        "nearest-exact",
+        "resize",
+        "0, 0, 0",
+        "center",
+        16,
+        "cpu"
+      ]
+    },
+    {
+      "id": 882,
+      "type": "LoraLoaderModelOnly",
+      "pos": [
+        -2748.7334137466864,
+        -205.6008119725589
+      ],
+      "size": [
+        387.5635967099787,
+        82
+      ],
+      "flags": {},
+      "order": 109,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "model",
+          "type": "MODEL",
+          "link": 1290
+        }
+      ],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": [
+            1011
+          ]
+        }
+      ],
+      "title": "Low LoRA SVI",
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.8.0",
+        "Node name for S&R": "LoraLoaderModelOnly",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "SVI_v2_PRO_Wan2.2-I2V-A14B_LOW_lora_rank_128_fp16.safetensors",
+        1
+      ],
+      "color": "#223",
+      "bgcolor": "#335"
+    },
+    {
+      "id": 881,
+      "type": "LoraLoaderModelOnly",
+      "pos": [
+        -2741.0858356216845,
+        -545.2399525975593
+      ],
+      "size": [
+        381.14311789279077,
+        82
+      ],
+      "flags": {},
+      "order": 116,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "model",
+          "type": "MODEL",
+          "link": 1006
+        }
+      ],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": [
+            1007
+          ]
+        }
+      ],
+      "title": "High LoRA SVI",
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.8.0",
+        "Node name for S&R": "LoraLoaderModelOnly",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "SVI_v2_PRO_Wan2.2-I2V-A14B_HIGH_lora_rank_128_fp16.safetensors",
+        1
+      ],
+      "color": "#223",
+      "bgcolor": "#335"
+    },
+    {
+      "id": 1109,
+      "type": "083335c7-23f1-4ebb-8fa5-df3fb44aa39f",
+      "pos": [
+        -473.2878315144023,
+        -822.8532613833652
+      ],
+      "size": [
+        183.0240234375,
+        66.40234375
+      ],
+      "flags": {
+        "collapsed": false
+      },
+      "order": 88,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "image",
+          "shape": 7,
+          "type": "IMAGE",
+          "link": 1457
+        },
+        {
+          "name": "IF_TRUE",
+          "type": "*",
+          "link": 1458
+        },
+        {
+          "name": "IF_FALSE",
+          "type": "*",
+          "link": 1459
+        }
+      ],
+      "outputs": [
+        {
+          "label": "Width",
+          "name": "?",
+          "type": "*",
+          "links": [
+            1460
+          ]
+        },
+        {
+          "label": "Height",
+          "name": "?_1",
+          "type": "*",
+          "links": [
+            1461
+          ]
+        }
+      ],
+      "properties": {
+        "proxyWidgets": [],
+        "cnr_id": "comfy-core",
+        "ver": "0.24.0",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "input_ue_unconnectable": {},
+          "version": "7.8"
+        }
+      },
+      "widgets_values": []
+    },
+    {
+      "id": 1095,
+      "type": "ImageBatchExtendWithOverlap",
+      "pos": [
+        814.1326108973956,
+        448.89724993139504
+      ],
+      "size": [
+        321.6236328125,
+        146
+      ],
+      "flags": {},
+      "order": 126,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "source_images",
+          "type": "IMAGE",
+          "link": 1430
+        },
+        {
+          "name": "new_images",
+          "shape": 7,
+          "type": "IMAGE",
+          "link": 1433
+        }
+      ],
+      "outputs": [
+        {
+          "name": "source_images",
+          "type": "IMAGE",
+          "links": []
+        },
+        {
+          "name": "start_images",
+          "type": "IMAGE",
+          "links": []
+        },
+        {
+          "name": "extended_images",
+          "type": "IMAGE",
+          "links": [
+            1463,
+            1465
+          ]
+        }
+      ],
+      "title": "Merge Pass 4 (chain)",
+      "properties": {
+        "cnr_id": "comfyui-kjnodes",
+        "ver": "79f529a84a8c20fe5dcdfa984c6be7a94102c014",
+        "Node name for S&R": "ImageBatchExtendWithOverlap",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        },
+        "aux_id": "kijai/ComfyUI-KJNodes"
+      },
+      "widgets_values": [
+        5,
+        "source",
+        "linear_blend"
+      ]
+    },
+    {
+      "id": 1108,
+      "type": "PrimitiveInt",
+      "pos": [
+        -709.2390150253793,
+        -887.3009928503395
+      ],
+      "size": [
+        210,
+        82
+      ],
+      "flags": {},
+      "order": 43,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "INT",
+          "type": "INT",
+          "links": [
+            1458
+          ]
+        }
+      ],
+      "title": "Width",
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.24.0",
+        "Node name for S&R": "PrimitiveInt",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "input_ue_unconnectable": {},
+          "version": "7.8"
+        }
+      },
+      "widgets_values": [
+        1280,
+        "fixed"
+      ]
+    },
+    {
+      "id": 1107,
+      "type": "PrimitiveInt",
+      "pos": [
+        -711.8993753043055,
+        -764.6258821194542
+      ],
+      "size": [
+        210,
+        83.99186466942149
+      ],
+      "flags": {},
+      "order": 44,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "INT",
+          "type": "INT",
+          "links": [
+            1459
+          ]
+        }
+      ],
+      "title": "Height",
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.24.0",
+        "Node name for S&R": "PrimitiveInt",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "input_ue_unconnectable": {},
+          "version": "7.8"
+        }
+      },
+      "widgets_values": [
+        720,
+        "fixed"
+      ]
+    },
+    {
+      "id": 1021,
+      "type": "Power Lora Loader (rgthree)",
+      "pos": [
+        -2209.295525301149,
+        -854.4158086346343
+      ],
+      "size": [
+        340.519921875,
+        142
+      ],
+      "flags": {},
+      "order": 76,
+      "mode": 0,
+      "inputs": [
+        {
+          "dir": 3,
+          "name": "model",
+          "type": "MODEL",
+          "link": 1388
+        },
+        {
+          "dir": 3,
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "dir": 4,
+          "name": "MODEL",
+          "shape": 3,
+          "type": "MODEL",
+          "links": [
+            1382
+          ]
+        },
+        {
+          "dir": 4,
+          "name": "CLIP",
+          "shape": 3,
+          "type": "CLIP",
+          "links": null
+        }
+      ],
+      "title": "Segment 1 High LoRAs",
+      "properties": {
+        "cnr_id": "rgthree-comfy",
+        "ver": "738105af5fb14e96fbecaf406dc356e284797e8c",
+        "Show Strengths": "Single Strength",
+        "Match": "",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "input_ue_unconnectable": {},
+          "version": "7.8"
+        }
+      },
+      "widgets_values": [
+        {},
+        {
+          "type": "PowerLoraLoaderHeaderWidget"
+        },
+        {
+          "on": true,
+          "lora": "DR34ML4Y_I2V_14B_HIGH_V2.safetensors",
+          "strength": 1,
+          "strengthTwo": null
+        },
+        {},
+        ""
+      ],
+      "color": "#323",
+      "bgcolor": "#535"
+    },
+    {
+      "id": 1022,
+      "type": "Power Lora Loader (rgthree)",
+      "pos": [
+        -2206.2809891206443,
+        -558.0958600527415
+      ],
+      "size": [
+        340.519921875,
+        142
+      ],
+      "flags": {},
+      "order": 74,
+      "mode": 0,
+      "inputs": [
+        {
+          "dir": 3,
+          "name": "model",
+          "type": "MODEL",
+          "link": 1386
+        },
+        {
+          "dir": 3,
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "dir": 4,
+          "name": "MODEL",
+          "shape": 3,
+          "type": "MODEL",
+          "links": [
+            1381
+          ]
+        },
+        {
+          "dir": 4,
+          "name": "CLIP",
+          "shape": 3,
+          "type": "CLIP",
+          "links": null
+        }
+      ],
+      "title": "Segment 1 Low LoRAs",
+      "properties": {
+        "cnr_id": "rgthree-comfy",
+        "ver": "738105af5fb14e96fbecaf406dc356e284797e8c",
+        "Show Strengths": "Single Strength",
+        "Match": "",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "input_ue_unconnectable": {},
+          "version": "7.8"
+        }
+      },
+      "widgets_values": [
+        {},
+        {
+          "type": "PowerLoraLoaderHeaderWidget"
+        },
+        {
+          "on": true,
+          "lora": "DR34ML4Y_I2V_14B_LOW_V2.safetensors",
+          "strength": 0.7,
+          "strengthTwo": null
+        },
+        {},
+        ""
+      ],
+      "color": "#323",
+      "bgcolor": "#535"
+    },
+    {
+      "id": 1002,
+      "type": "DiffusionModelLoaderKJ",
+      "pos": [
+        -3470.9169513816737,
+        -620.069760302186
+      ],
+      "size": [
+        312.095703125,
+        178
+      ],
+      "flags": {},
+      "order": 45,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "extra_state_dict",
+          "shape": 7,
+          "type": "STRING",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": [
+            1473,
+            1474
+          ]
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfyui-kjnodes",
+        "ver": "204f6d5aae73b10c0fe2fb26e61405fd6337bb77",
+        "Node name for S&R": "DiffusionModelLoaderKJ",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "input_ue_unconnectable": {},
+          "version": "7.8"
+        }
+      },
+      "widgets_values": [
+        "wan2.2_i2v_high_noise_14B_fp16.safetensors",
+        "default",
+        "default",
+        false,
+        "auto",
+        true
+      ]
+    },
+    {
+      "id": 1003,
+      "type": "DiffusionModelLoaderKJ",
+      "pos": [
+        -3476.9601352542295,
+        -392.50103935693784
+      ],
+      "size": [
+        312.095703125,
+        178
+      ],
+      "flags": {},
+      "order": 46,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "extra_state_dict",
+          "shape": 7,
+          "type": "STRING",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": [
+            1475
+          ]
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfyui-kjnodes",
+        "ver": "204f6d5aae73b10c0fe2fb26e61405fd6337bb77",
+        "Node name for S&R": "DiffusionModelLoaderKJ",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "input_ue_unconnectable": {},
+          "version": "7.8"
+        }
+      },
+      "widgets_values": [
+        "wan2.2_i2v_low_noise_14B_fp16.safetensors",
+        "default",
+        "default",
+        false,
+        "auto",
+        true
+      ]
+    },
+    {
+      "id": 1008,
+      "type": "KSamplerSelect",
+      "pos": [
+        -268.67970888699216,
+        -705.9422811964176
+      ],
+      "size": [
+        270,
+        58
+      ],
+      "flags": {},
+      "order": 47,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "SAMPLER",
+          "type": "SAMPLER",
+          "links": [
+            1403
+          ]
+        }
+      ],
+      "title": "KSamplerHigh",
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.24.0",
+        "Node name for S&R": "KSamplerSelect",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "input_ue_unconnectable": {},
+          "version": "7.8"
+        }
+      },
+      "widgets_values": [
+        "euler"
+      ],
+      "color": "#232",
+      "bgcolor": "#353"
+    },
+    {
+      "id": 1078,
+      "type": "SetNode",
+      "pos": [
+        -212.4292241435317,
+        -606.5833019217251
+      ],
+      "size": [
+        210,
+        60
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 85,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "SAMPLER",
+          "type": "SAMPLER",
+          "link": 1403
+        }
+      ],
+      "outputs": [
+        {
+          "name": "*",
+          "type": "*",
+          "links": null
+        }
+      ],
+      "title": "Set_SamplerHigh",
+      "properties": {
+        "previousName": "SamplerHigh",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "SamplerHigh"
+      ],
+      "color": "#614a4a",
+      "bgcolor": "#3b2c2c"
+    },
+    {
+      "id": 1120,
+      "type": "SetNode",
+      "pos": [
+        -215.25283806228467,
+        -463.9116464739158
+      ],
+      "size": [
+        210,
+        50
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 94,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "SAMPLER",
+          "type": "SAMPLER",
+          "link": 1481
+        }
+      ],
+      "outputs": [
+        {
+          "name": "*",
+          "type": "*",
+          "links": null
+        }
+      ],
+      "title": "Set_SamplerLow",
+      "properties": {
+        "previousName": "SamplerLow",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "SamplerLow"
+      ],
+      "color": "#614a4a",
+      "bgcolor": "#3b2c2c"
+    },
+    {
+      "id": 987,
+      "type": "GetNode",
+      "pos": [
+        93.04706254573455,
+        -705.9847838111137
+      ],
+      "size": [
+        210,
+        34
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 48,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "INT",
+          "type": "INT",
+          "links": [
+            1266
+          ]
+        }
+      ],
+      "title": "Get_seed",
+      "properties": {
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "seed"
+      ],
+      "color": "#1b4669",
+      "bgcolor": "#29699c"
+    },
+    {
+      "id": 1098,
+      "type": "GetNode",
+      "pos": [
+        80.10155207618182,
+        -636.9885487843981
+      ],
+      "size": [
+        210,
+        58
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 49,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "SAMPLER",
+          "type": "SAMPLER",
+          "links": [
+            1442,
+            1443
+          ]
+        }
+      ],
+      "title": "Get_SamplerHigh",
+      "properties": {
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "SamplerHigh"
+      ],
+      "color": "#614a4a",
+      "bgcolor": "#3b2c2c"
+    },
+    {
+      "id": 986,
+      "type": "GetNode",
+      "pos": [
+        101.18795860602836,
+        -8.335262950388506
+      ],
+      "size": [
+        210,
+        60
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 50,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "INT",
+          "type": "INT",
+          "links": [
+            1265
+          ]
+        }
+      ],
+      "title": "Get_seed",
+      "properties": {
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "seed"
+      ],
+      "color": "#1b4669",
+      "bgcolor": "#29699c"
+    },
+    {
+      "id": 1097,
+      "type": "GetNode",
+      "pos": [
+        106.71746123891421,
+        177.950318232263
+      ],
+      "size": [
+        210,
+        50
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 51,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": [
+            1436
+          ]
+        }
+      ],
+      "title": "Get_SEG3_HighModel",
+      "properties": {
+        "Node name for S&R": "GetNode",
+        "aux_id": "kijai/ComfyUI-KJNodes",
+        "previousName": "svi model lightning low",
+        "ue_properties": {
+          "version": "7.8",
+          "widget_ue_connectable": {},
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "SEG3_HighModel"
+      ],
+      "color": "#223",
+      "bgcolor": "#335"
+    },
+    {
+      "id": 1031,
+      "type": "GetNode",
+      "pos": [
+        82.35189903109963,
+        -311.67511827078016
+      ],
+      "size": [
+        210,
+        50
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 52,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": [
+            1389
+          ]
+        }
+      ],
+      "title": "Get_SEG2_HighModel",
+      "properties": {
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "SEG2_HighModel"
+      ],
+      "color": "#223",
+      "bgcolor": "#335"
+    },
+    {
+      "id": 1133,
+      "type": "SetNode",
+      "pos": [
+        -544.9504323688487,
+        -393.74098062978067
+      ],
+      "size": [
+        210,
+        58
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 93,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "FLOAT",
+          "type": "FLOAT",
+          "link": 1488
+        }
+      ],
+      "outputs": [
+        {
+          "name": "*",
+          "type": "*",
+          "links": null
+        }
+      ],
+      "title": "Set_CFGLow",
+      "properties": {
+        "previousName": "CFGLow",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "CFGLow"
+      ],
+      "color": "#232",
+      "bgcolor": "#353"
+    },
+    {
+      "id": 1132,
+      "type": "SetNode",
+      "pos": [
+        -704.3570697655427,
+        -394.3472564562268
+      ],
+      "size": [
+        210,
+        60
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 86,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "FLOAT",
+          "type": "FLOAT",
+          "link": 1487
+        }
+      ],
+      "outputs": [
+        {
+          "name": "*",
+          "type": "*",
+          "links": null
+        }
+      ],
+      "title": "Set_CFGHigh",
+      "properties": {
+        "previousName": "CFGHigh",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "CFGHigh"
+      ],
+      "color": "#232",
+      "bgcolor": "#353"
+    },
+    {
+      "id": 1130,
+      "type": "Float",
+      "pos": [
+        -704.3802134897167,
+        -617.1084296225492
+      ],
+      "size": [
+        270,
+        58
+      ],
+      "flags": {},
+      "order": 53,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "FLOAT",
+          "type": "FLOAT",
+          "links": [
+            1487
+          ]
+        }
+      ],
+      "title": "CFGHigh",
+      "properties": {
+        "cnr_id": "ComfyLiterals",
+        "ver": "bdddb08ca82d90d75d97b1d437a652e0284a32ac",
+        "Node name for S&R": "Float",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "input_ue_unconnectable": {},
+          "version": "7.8"
+        }
+      },
+      "widgets_values": [
+        "1"
+      ],
+      "color": "#232",
+      "bgcolor": "#353"
+    },
+    {
+      "id": 1128,
+      "type": "GetNode",
+      "pos": [
+        84.84993909721867,
+        -590.7836276724526
+      ],
+      "size": [
+        210,
+        50
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 54,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "SAMPLER",
+          "type": "SAMPLER",
+          "links": [
+            1486,
+            1499
+          ]
+        }
+      ],
+      "title": "Get_SamplerLow",
+      "properties": {
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "SamplerLow"
+      ],
+      "color": "#614a4a",
+      "bgcolor": "#3b2c2c"
+    },
+    {
+      "id": 1134,
+      "type": "GetNode",
+      "pos": [
+        92.67574412593673,
+        -455.753847444742
+      ],
+      "size": [
+        210,
+        50
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 55,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "FLOAT",
+          "type": "FLOAT",
+          "links": [
+            1500,
+            1501
+          ]
+        }
+      ],
+      "title": "Get_CFGHigh",
+      "properties": {
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "CFGHigh"
+      ],
+      "color": "#232",
+      "bgcolor": "#353"
+    },
+    {
+      "id": 1135,
+      "type": "GetNode",
+      "pos": [
+        88.17535350093675,
+        -414.7503318197421
+      ],
+      "size": [
+        210,
+        50
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 56,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "FLOAT",
+          "type": "FLOAT",
+          "links": [
+            1502,
+            1503
+          ]
+        }
+      ],
+      "title": "Get_CFGLow",
+      "properties": {
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "CFGLow"
+      ],
+      "color": "#232",
+      "bgcolor": "#353"
+    },
+    {
+      "id": 1137,
+      "type": "GetNode",
+      "pos": [
+        115.53182315742384,
+        745.5107450640116
+      ],
+      "size": [
+        210,
+        34
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 57,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "FLOAT",
+          "type": "FLOAT",
+          "links": [
+            1508,
+            1509
+          ]
+        }
+      ],
+      "title": "Get_CFGLow",
+      "properties": {
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "CFGLow"
+      ],
+      "color": "#232",
+      "bgcolor": "#353"
+    },
+    {
+      "id": 1136,
+      "type": "GetNode",
+      "pos": [
+        120.0322137824238,
+        704.5072294390118
+      ],
+      "size": [
+        210,
+        34
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 58,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "FLOAT",
+          "type": "FLOAT",
+          "links": [
+            1506,
+            1507
+          ]
+        }
+      ],
+      "title": "Get_CFGHigh",
+      "properties": {
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "CFGHigh"
+      ],
+      "color": "#232",
+      "bgcolor": "#353"
+    },
+    {
+      "id": 1079,
+      "type": "GetNode",
+      "pos": [
+        111.14270501677201,
+        526.5122322130599
+      ],
+      "size": [
+        210,
+        60
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 59,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "SAMPLER",
+          "type": "SAMPLER",
+          "links": [
+            1404,
+            1405
+          ]
+        }
+      ],
+      "title": "Get_SamplerHigh",
+      "properties": {
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "SamplerHigh"
+      ],
+      "color": "#614a4a",
+      "bgcolor": "#3b2c2c"
+    },
+    {
+      "id": 1092,
+      "type": "GetNode",
+      "pos": [
+        117.89832178830578,
+        618.469545061334
+      ],
+      "size": [
+        210,
+        34
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 60,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "SIGMAS",
+          "type": "SIGMAS",
+          "links": [
+            1426,
+            1428
+          ]
+        }
+      ],
+      "title": "Get_sigmas_high",
+      "properties": {
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "sigmas_high"
+      ],
+      "color": "#485248",
+      "bgcolor": "#272e27"
+    },
+    {
+      "id": 1138,
+      "type": "GetNode",
+      "pos": [
+        117.61892120760598,
+        571.1881103122332
+      ],
+      "size": [
+        210,
+        50
+      ],
+      "flags": {
+        "collapsed": true
+      },
+      "order": 61,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "SAMPLER",
+          "type": "SAMPLER",
+          "links": [
+            1504,
+            1505
+          ]
+        }
+      ],
+      "title": "Get_SamplerLow",
+      "properties": {
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "SamplerLow"
+      ],
+      "color": "#614a4a",
+      "bgcolor": "#3b2c2c"
+    },
+    {
+      "id": 1023,
+      "type": "Power Lora Loader (rgthree)",
+      "pos": [
+        -1446.578199124869,
+        -845.5771023194809
+      ],
+      "size": [
+        340.519921875,
+        142
+      ],
+      "flags": {},
+      "order": 79,
+      "mode": 0,
+      "inputs": [
+        {
+          "dir": 3,
+          "name": "model",
+          "type": "MODEL",
+          "link": 1421
+        },
+        {
+          "dir": 3,
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "dir": 4,
+          "name": "MODEL",
+          "shape": 3,
+          "type": "MODEL",
+          "links": [
+            1383
+          ]
+        },
+        {
+          "dir": 4,
+          "name": "CLIP",
+          "shape": 3,
+          "type": "CLIP",
+          "links": null
+        }
+      ],
+      "title": "Segment 2 High LoRAs",
+      "properties": {
+        "cnr_id": "rgthree-comfy",
+        "ver": "738105af5fb14e96fbecaf406dc356e284797e8c",
+        "Show Strengths": "Single Strength",
+        "Match": "",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "input_ue_unconnectable": {},
+          "version": "7.8"
+        }
+      },
+      "widgets_values": [
+        {},
+        {
+          "type": "PowerLoraLoaderHeaderWidget"
+        },
+        {
+          "on": true,
+          "lora": "DR34ML4Y_I2V_14B_HIGH_V2.safetensors",
+          "strength": 0.8,
+          "strengthTwo": null
+        },
+        {},
+        ""
+      ],
+      "color": "#323",
+      "bgcolor": "#535"
+    },
+    {
+      "id": 1024,
+      "type": "Power Lora Loader (rgthree)",
+      "pos": [
+        -1436.1488667385054,
+        -564.153451751299
+      ],
+      "size": [
+        340.519921875,
+        142
+      ],
+      "flags": {},
+      "order": 81,
+      "mode": 0,
+      "inputs": [
+        {
+          "dir": 3,
+          "name": "model",
+          "type": "MODEL",
+          "link": 1423
+        },
+        {
+          "dir": 3,
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "dir": 4,
+          "name": "MODEL",
+          "shape": 3,
+          "type": "MODEL",
+          "links": [
+            1384
+          ]
+        },
+        {
+          "dir": 4,
+          "name": "CLIP",
+          "shape": 3,
+          "type": "CLIP",
+          "links": null
+        }
+      ],
+      "title": "Segment 2 Low LoRAs",
+      "properties": {
+        "cnr_id": "rgthree-comfy",
+        "ver": "738105af5fb14e96fbecaf406dc356e284797e8c",
+        "Show Strengths": "Single Strength",
+        "Match": "",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "input_ue_unconnectable": {},
+          "version": "7.8"
+        }
+      },
+      "widgets_values": [
+        {},
+        {
+          "type": "PowerLoraLoaderHeaderWidget"
+        },
+        {
+          "on": true,
+          "lora": "DR34ML4Y_I2V_14B_LOW_V2.safetensors",
+          "strength": 0.8,
+          "strengthTwo": null
+        },
+        {},
+        ""
+      ],
+      "color": "#323",
+      "bgcolor": "#535"
+    },
+    {
+      "id": 1083,
+      "type": "Power Lora Loader (rgthree)",
+      "pos": [
+        -2172.337320559659,
+        -95.59774870615728
+      ],
+      "size": [
+        340.519921875,
+        166
+      ],
+      "flags": {},
+      "order": 77,
+      "mode": 0,
+      "inputs": [
+        {
+          "dir": 3,
+          "name": "model",
+          "type": "MODEL",
+          "link": 1419
+        },
+        {
+          "dir": 3,
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "dir": 4,
+          "name": "MODEL",
+          "shape": 3,
+          "type": "MODEL",
+          "links": [
+            1412
+          ]
+        },
+        {
+          "dir": 4,
+          "name": "CLIP",
+          "shape": 3,
+          "type": "CLIP",
+          "links": null
+        }
+      ],
+      "title": "Segment 3 High LoRAs",
+      "properties": {
+        "cnr_id": "rgthree-comfy",
+        "ver": "738105af5fb14e96fbecaf406dc356e284797e8c",
+        "Show Strengths": "Single Strength",
+        "Match": "",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "input_ue_unconnectable": {},
+          "version": "7.8"
+        }
+      },
+      "widgets_values": [
+        {},
+        {
+          "type": "PowerLoraLoaderHeaderWidget"
+        },
+        {
+          "on": true,
+          "lora": "DR34ML4Y_I2V_14B_HIGH_V2.safetensors",
+          "strength": 0.75,
+          "strengthTwo": null
+        },
+        {
+          "on": false,
+          "lora": "smash_cut_wan_high_250.safetensors",
+          "strength": 1,
+          "strengthTwo": null
+        },
+        {},
+        ""
+      ],
+      "color": "#323",
+      "bgcolor": "#535"
+    },
+    {
+      "id": 1082,
+      "type": "Power Lora Loader (rgthree)",
+      "pos": [
+        -2181.2423533721617,
+        239.41324973134243
+      ],
+      "size": [
+        340.519921875,
+        142
+      ],
+      "flags": {},
+      "order": 75,
+      "mode": 0,
+      "inputs": [
+        {
+          "dir": 3,
+          "name": "model",
+          "type": "MODEL",
+          "link": 1417
+        },
+        {
+          "dir": 3,
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "dir": 4,
+          "name": "MODEL",
+          "shape": 3,
+          "type": "MODEL",
+          "links": [
+            1413
+          ]
+        },
+        {
+          "dir": 4,
+          "name": "CLIP",
+          "shape": 3,
+          "type": "CLIP",
+          "links": null
+        }
+      ],
+      "title": "Segment 3 Low LoRAs",
+      "properties": {
+        "cnr_id": "rgthree-comfy",
+        "ver": "738105af5fb14e96fbecaf406dc356e284797e8c",
+        "Show Strengths": "Single Strength",
+        "Match": "",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "input_ue_unconnectable": {},
+          "version": "7.8"
+        }
+      },
+      "widgets_values": [
+        {},
+        {
+          "type": "PowerLoraLoaderHeaderWidget"
+        },
+        {
+          "on": true,
+          "lora": "DR34ML4Y_I2V_14B_LOW_V2.safetensors",
+          "strength": 0.78,
+          "strengthTwo": null
+        },
+        {},
+        ""
+      ],
+      "color": "#323",
+      "bgcolor": "#535"
+    },
+    {
+      "id": 1086,
+      "type": "Power Lora Loader (rgthree)",
+      "pos": [
+        -1437.7801778490664,
+        -96.73906759926989
+      ],
+      "size": [
+        340.519921875,
+        166
+      ],
+      "flags": {},
+      "order": 78,
+      "mode": 0,
+      "inputs": [
+        {
+          "dir": 3,
+          "name": "model",
+          "type": "MODEL",
+          "link": 1420
+        },
+        {
+          "dir": 3,
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "dir": 4,
+          "name": "MODEL",
+          "shape": 3,
+          "type": "MODEL",
+          "links": [
+            1414
+          ]
+        },
+        {
+          "dir": 4,
+          "name": "CLIP",
+          "shape": 3,
+          "type": "CLIP",
+          "links": null
+        }
+      ],
+      "title": "Segment 4 High LoRAs",
+      "properties": {
+        "cnr_id": "rgthree-comfy",
+        "ver": "738105af5fb14e96fbecaf406dc356e284797e8c",
+        "Show Strengths": "Single Strength",
+        "Match": "",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "input_ue_unconnectable": {},
+          "version": "7.8"
+        }
+      },
+      "widgets_values": [
+        {},
+        {
+          "type": "PowerLoraLoaderHeaderWidget"
+        },
+        {
+          "on": true,
+          "lora": "DR34ML4Y_I2V_14B_HIGH_V2.safetensors",
+          "strength": 0.75,
+          "strengthTwo": null
+        },
+        {
+          "on": false,
+          "lora": "smash_cut_wan_high_250.safetensors",
+          "strength": 1,
+          "strengthTwo": null
+        },
+        {},
+        ""
+      ],
+      "color": "#323",
+      "bgcolor": "#535"
+    },
+    {
+      "id": 1087,
+      "type": "Power Lora Loader (rgthree)",
+      "pos": [
+        -1449.8143127471583,
+        250.35299703247927
+      ],
+      "size": [
+        340.519921875,
+        142
+      ],
+      "flags": {},
+      "order": 80,
+      "mode": 0,
+      "inputs": [
+        {
+          "dir": 3,
+          "name": "model",
+          "type": "MODEL",
+          "link": 1422
+        },
+        {
+          "dir": 3,
+          "name": "clip",
+          "type": "CLIP",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "dir": 4,
+          "name": "MODEL",
+          "shape": 3,
+          "type": "MODEL",
+          "links": [
+            1415
+          ]
+        },
+        {
+          "dir": 4,
+          "name": "CLIP",
+          "shape": 3,
+          "type": "CLIP",
+          "links": null
+        }
+      ],
+      "title": "Segment 4 Low LoRAs",
+      "properties": {
+        "cnr_id": "rgthree-comfy",
+        "ver": "738105af5fb14e96fbecaf406dc356e284797e8c",
+        "Show Strengths": "Single Strength",
+        "Match": "",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "input_ue_unconnectable": {},
+          "version": "7.8"
+        }
+      },
+      "widgets_values": [
+        {},
+        {
+          "type": "PowerLoraLoaderHeaderWidget"
+        },
+        {
+          "on": true,
+          "lora": "DR34ML4Y_I2V_14B_LOW_V2.safetensors",
+          "strength": 0.85,
+          "strengthTwo": null
+        },
+        {},
+        ""
+      ],
+      "color": "#323",
+      "bgcolor": "#535"
+    },
+    {
+      "id": 62,
+      "type": "LoadImage",
+      "pos": [
+        -926.2699382434265,
+        -1274.030050986821
+      ],
+      "size": [
+        315,
+        314.0000305175781
+      ],
+      "flags": {},
+      "order": 62,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "slot_index": 0,
+          "links": [
+            1013,
+            1457
+          ]
+        },
+        {
+          "name": "MASK",
+          "type": "MASK",
+          "slot_index": 1,
+          "links": null
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.3.45",
+        "Node name for S&R": "LoadImage",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "ComfyUI_temp_zfgpx_00044_.png",
+        "image"
+      ],
+      "color": "#232",
+      "bgcolor": "#353"
+    },
+    {
+      "id": 950,
+      "type": "PrimitiveStringMultiline",
+      "pos": [
+        -947.9839809430988,
+        -134.0167219658383
+      ],
+      "size": [
+        400,
+        200
+      ],
+      "flags": {},
+      "order": 63,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "STRING",
+          "type": "STRING",
+          "links": [
+            1160
+          ]
+        }
+      ],
+      "title": "Segment 1 Prompt",
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.22.0",
+        "Node name for S&R": "PrimitiveStringMultiline",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "input_ue_unconnectable": {},
+          "version": "7.8"
+        }
+      },
+      "widgets_values": [
+        "`bl0wj0b`, pov, a young woman with long brown hair, striking green eyes, wearing a black top and a delicate gold necklace. Starting from the position in the image where she has the erect penis at her lips, she takes it deeper into her mouth and begins a steady, rhythmic head-bobbing motion up and down the shaft. A visible sheen of saliva coats the glans and shaft as she sucks, her eyes locked onto the viewer with intense focus. Soft, natural indoor lighting, consistent with the reference frame."
+      ],
+      "color": "#232",
+      "bgcolor": "#353"
+    },
+    {
+      "id": 990,
+      "type": "PrimitiveStringMultiline",
+      "pos": [
+        -468.725317344301,
+        -133.9266815826677
+      ],
+      "size": [
+        400,
+        200
+      ],
+      "flags": {},
+      "order": 64,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "STRING",
+          "type": "STRING",
+          "links": [
+            1272
+          ]
+        }
+      ],
+      "title": "Segment 2 Prompt",
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.22.0",
+        "Node name for S&R": "PrimitiveStringMultiline",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "input_ue_unconnectable": {},
+          "version": "7.8"
+        }
+      },
+      "widgets_values": [
+        "`bl0wj0b`, pov, a young woman with long brown hair, striking green eyes, wearing a black top and a delicate gold necklace. Starting from the position in the image where she has the erect penis at her lips, she takes it deeper into her mouth and begins a steady very fast rhythmic head-bobbing motion up and down the shaft. A visible sheen of saliva coats the glans and shaft as she sucks, her eyes locked onto the viewer with intense focus. Soft, natural indoor lighting, consistent with the reference frame."
+      ],
+      "color": "#232",
+      "bgcolor": "#353"
+    },
+    {
+      "id": 1050,
+      "type": "PrimitiveStringMultiline",
+      "pos": [
+        -935.5877293901161,
+        276.79786296692726
+      ],
+      "size": [
+        400,
+        200
+      ],
+      "flags": {},
+      "order": 65,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "STRING",
+          "type": "STRING",
+          "links": [
+            1393
+          ]
+        }
+      ],
+      "title": "Segment 3 Prompt",
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.22.0",
+        "Node name for S&R": "PrimitiveStringMultiline",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "input_ue_unconnectable": {},
+          "version": "7.8"
+        }
+      },
+      "widgets_values": [
+        "`bl0wj0b`, pov, a young woman with long brown hair, striking green eyes, wearing a black top and a delicate gold necklace. Starting from the position in the image where she has the erect penis at her lips, her hand goes into frame, she has black nail polish and feminine nails, she grabs the penis and strokes it moving her hand up and down she takes it deeper into her mouth and begins a steady very fast rhythmic head-bobbing motion up and down the shaft. A visible sheen of saliva coats the glans and shaft as she sucks, her eyes locked onto the viewer with intense focus. Soft, natural indoor lighting, consistent with the reference frame."
+      ],
+      "color": "#232",
+      "bgcolor": "#353"
+    },
+    {
+      "id": 1049,
+      "type": "PrimitiveStringMultiline",
+      "pos": [
+        -450.70007443143805,
+        268.30970791433515
+      ],
+      "size": [
+        400,
+        200
+      ],
+      "flags": {},
+      "order": 66,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "STRING",
+          "type": "STRING",
+          "links": [
+            1394
+          ]
+        }
+      ],
+      "title": "Segment 4 Prompt",
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.22.0",
+        "Node name for S&R": "PrimitiveStringMultiline",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "input_ue_unconnectable": {},
+          "version": "7.8"
+        }
+      },
+      "widgets_values": [
+        "`bl0wj0b`, pov, a young woman with long brown hair, striking green eyes, wearing a black top and a delicate gold necklace. Starting from the position in the image where she has the erect penis at her lips, her hand goes into frame, she has black nail polish and feminine nails, she grabs the penis and strokes it moving her hand up and down she takes it deeper into her mouth and begins a steady very fast rhythmic head-bobbing motion up and down the shaft. A visible sheen of saliva coats the glans and shaft as she sucks, her eyes locked onto the viewer with intense focus. Soft, natural indoor lighting, consistent with the reference frame."
+      ],
+      "color": "#232",
+      "bgcolor": "#353"
+    },
+    {
+      "id": 1111,
+      "type": "VHS_VideoCombine",
+      "pos": [
+        1215.9013138106836,
+        -139.1200535900038
+      ],
+      "size": [
+        647.1444197150872,
+        692.929430843298
+      ],
+      "flags": {},
+      "order": 128,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "link": 1465
+        },
+        {
+          "name": "audio",
+          "shape": 7,
+          "type": "AUDIO",
+          "link": null
+        },
+        {
+          "name": "meta_batch",
+          "shape": 7,
+          "type": "VHS_BatchManager",
+          "link": null
+        },
+        {
+          "name": "vae",
+          "shape": 7,
+          "type": "VAE",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "Filenames",
+          "type": "VHS_FILENAMES",
+          "links": null
+        }
+      ],
+      "title": "Final Video + Upscale and interpolation",
+      "properties": {
+        "cnr_id": "comfyui-videohelpersuite",
+        "ver": "8550981384301e9bc5bfea83e5c2c75258102593",
+        "Node name for S&R": "VHS_VideoCombine",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": {
+        "frame_rate": 16,
+        "loop_count": 0,
+        "filename_prefix": "Wan2.2_SVI_4pass_MoreMotion",
+        "format": "video/h264-mp4",
+        "pix_fmt": "yuv420p",
+        "crf": 19,
+        "save_metadata": true,
+        "trim_to_audio": false,
+        "pingpong": false,
+        "save_output": true,
+        "videopreview": {
+          "hidden": false,
+          "paused": false,
+          "params": {
+            "filename": "Wan2.2_SVI_4pass_MoreMotion_00105.mp4",
+            "subfolder": "",
+            "type": "output",
+            "format": "video/h264-mp4",
+            "frame_rate": 16,
+            "workflow": "Wan2.2_SVI_4pass_MoreMotion_00105.png",
+            "fullpath": "/ComfyUI/output/Wan2.2_SVI_4pass_MoreMotion_00105.mp4"
+          }
+        }
+      }
+    },
+    {
+      "id": 512,
+      "type": "VHS_VideoCombine",
+      "pos": [
+        1891.8817523221676,
+        -134.0389398519958
+      ],
+      "size": [
+        647.1444197150872,
+        693.2171117697728
+      ],
+      "flags": {},
+      "order": 129,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "link": 1523
+        },
+        {
+          "name": "audio",
+          "shape": 7,
+          "type": "AUDIO",
+          "link": null
+        },
+        {
+          "name": "meta_batch",
+          "shape": 7,
+          "type": "VHS_BatchManager",
+          "link": null
+        },
+        {
+          "name": "vae",
+          "shape": 7,
+          "type": "VAE",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "Filenames",
+          "type": "VHS_FILENAMES",
+          "links": null
+        }
+      ],
+      "title": "Final Video + Upscale and interpolation",
+      "properties": {
+        "cnr_id": "comfyui-videohelpersuite",
+        "ver": "8550981384301e9bc5bfea83e5c2c75258102593",
+        "Node name for S&R": "VHS_VideoCombine",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": {
+        "frame_rate": 16,
+        "loop_count": 0,
+        "filename_prefix": "Wan2.2_SVI_4pass_MoreMotion",
+        "format": "video/h264-mp4",
+        "pix_fmt": "yuv420p",
+        "crf": 19,
+        "save_metadata": true,
+        "trim_to_audio": false,
+        "pingpong": false,
+        "save_output": true,
+        "videopreview": {
+          "hidden": false,
+          "paused": false,
+          "params": {
+            "filename": "Wan2.2_SVI_4pass_MoreMotion_00099.mp4",
+            "subfolder": "",
+            "type": "output",
+            "format": "video/h264-mp4",
+            "frame_rate": 16,
+            "workflow": "Wan2.2_SVI_4pass_MoreMotion_00099.png",
+            "fullpath": "/ComfyUI/output/Wan2.2_SVI_4pass_MoreMotion_00099.mp4"
+          }
+        }
+      }
+    },
+    {
+      "id": 1151,
+      "type": "2a6f6651-87f0-4f47-94cc-ce5d2e872b6e",
+      "pos": [
+        1814.9435534076713,
+        841.1750850349677
+      ],
+      "size": [
+        140,
+        26
+      ],
+      "flags": {},
+      "order": 130,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "image",
+          "type": "IMAGE",
+          "link": 1525
+        }
+      ],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": [
+            1527,
+            1528
+          ]
+        }
+      ],
+      "title": "Upscale & Interpolate",
+      "properties": {
+        "proxyWidgets": [],
+        "cnr_id": "comfy-core",
+        "ver": "0.24.0",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": []
+    },
+    {
+      "id": 1117,
+      "type": "VHS_VideoCombine",
+      "pos": [
+        2573.031017136107,
+        -139.64955221797203
+      ],
+      "size": [
+        647.1444197150872,
+        693.2171117697728
+      ],
+      "flags": {},
+      "order": 131,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "link": 1527
+        },
+        {
+          "name": "audio",
+          "shape": 7,
+          "type": "AUDIO",
+          "link": null
+        },
+        {
+          "name": "meta_batch",
+          "shape": 7,
+          "type": "VHS_BatchManager",
+          "link": null
+        },
+        {
+          "name": "vae",
+          "shape": 7,
+          "type": "VAE",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "Filenames",
+          "type": "VHS_FILENAMES",
+          "links": null
+        }
+      ],
+      "title": "Final Video + Upscale and interpolation",
+      "properties": {
+        "cnr_id": "comfyui-videohelpersuite",
+        "ver": "8550981384301e9bc5bfea83e5c2c75258102593",
+        "Node name for S&R": "VHS_VideoCombine",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": {
+        "frame_rate": 50,
+        "loop_count": 0,
+        "filename_prefix": "Wan2.2_SVI_4pass_MoreMotion",
+        "format": "video/h264-mp4",
+        "pix_fmt": "yuv420p",
+        "crf": 19,
+        "save_metadata": true,
+        "trim_to_audio": false,
+        "pingpong": false,
+        "save_output": true,
+        "videopreview": {
+          "hidden": false,
+          "paused": false,
+          "params": {
+            "filename": "Wan2.2_SVI_4pass_MoreMotion_00100.mp4",
+            "subfolder": "",
+            "type": "output",
+            "format": "video/h264-mp4",
+            "frame_rate": 50,
+            "workflow": "Wan2.2_SVI_4pass_MoreMotion_00100.png",
+            "fullpath": "/ComfyUI/output/Wan2.2_SVI_4pass_MoreMotion_00100.mp4"
+          }
+        }
+      }
+    },
+    {
+      "id": 1118,
+      "type": "VHS_VideoCombine",
+      "pos": [
+        3247.3567272295836,
+        -135.66501651930037
+      ],
+      "size": [
+        647.1444197150872,
+        693.2171117697728
+      ],
+      "flags": {},
+      "order": 132,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "link": 1528
+        },
+        {
+          "name": "audio",
+          "shape": 7,
+          "type": "AUDIO",
+          "link": null
+        },
+        {
+          "name": "meta_batch",
+          "shape": 7,
+          "type": "VHS_BatchManager",
+          "link": null
+        },
+        {
+          "name": "vae",
+          "shape": 7,
+          "type": "VAE",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "Filenames",
+          "type": "VHS_FILENAMES",
+          "links": null
+        }
+      ],
+      "title": "Final Video + Upscale and interpolation",
+      "properties": {
+        "cnr_id": "comfyui-videohelpersuite",
+        "ver": "8550981384301e9bc5bfea83e5c2c75258102593",
+        "Node name for S&R": "VHS_VideoCombine",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": {
+        "frame_rate": 60,
+        "loop_count": 0,
+        "filename_prefix": "Wan2.2_SVI_4pass_MoreMotion",
+        "format": "video/h264-mp4",
+        "pix_fmt": "yuv420p",
+        "crf": 19,
+        "save_metadata": true,
+        "trim_to_audio": false,
+        "pingpong": false,
+        "save_output": true,
+        "videopreview": {
+          "hidden": false,
+          "paused": false,
+          "params": {
+            "filename": "Wan2.2_SVI_4pass_MoreMotion_00101.mp4",
+            "subfolder": "",
+            "type": "output",
+            "format": "video/h264-mp4",
+            "frame_rate": 60,
+            "workflow": "Wan2.2_SVI_4pass_MoreMotion_00101.png",
+            "fullpath": "/ComfyUI/output/Wan2.2_SVI_4pass_MoreMotion_00101.mp4"
+          }
+        }
+      }
+    },
+    {
+      "id": 1044,
+      "type": "85e58d71-a4c3-4d0b-bbc9-1cb3b2979700",
+      "pos": [
+        510.21041762116545,
+        762.7494732150113
+      ],
+      "size": [
+        210,
+        370
+      ],
+      "flags": {},
+      "order": 124,
+      "mode": 0,
+      "inputs": [
+        {
+          "label": "high_model",
+          "name": "model_1",
+          "type": "MODEL",
+          "link": 1424
+        },
+        {
+          "name": "vae",
+          "type": "VAE",
+          "link": 1407
+        },
+        {
+          "label": "low_model",
+          "name": "model_2",
+          "type": "MODEL",
+          "link": 1425
+        },
+        {
+          "name": "positive",
+          "type": "CONDITIONING",
+          "link": 1408
+        },
+        {
+          "name": "negative",
+          "type": "CONDITIONING",
+          "link": 1409
+        },
+        {
+          "name": "anchor_samples",
+          "type": "LATENT",
+          "link": 1406
+        },
+        {
+          "name": "prev_samples",
+          "shape": 7,
+          "type": "LATENT",
+          "link": 1392
+        },
+        {
+          "label": "seed",
+          "name": "value",
+          "type": "INT",
+          "widget": {
+            "name": "value"
+          },
+          "link": 1411
+        },
+        {
+          "label": "SamplerHigh",
+          "name": "sampler",
+          "type": "SAMPLER",
+          "link": 1405
+        },
+        {
+          "label": "sigmas_high",
+          "name": "sigmas",
+          "type": "SIGMAS",
+          "link": 1426
+        },
+        {
+          "label": "sigmas_low",
+          "name": "sigmas_1",
+          "type": "SIGMAS",
+          "link": 1427
+        },
+        {
+          "name": "length",
+          "type": "INT",
+          "widget": {
+            "name": "length"
+          },
+          "link": 1410
+        },
+        {
+          "label": "SamplerLow",
+          "name": "sampler_1",
+          "type": "SAMPLER",
+          "link": 1505
+        },
+        {
+          "label": "CFGHigh",
+          "name": "cfg",
+          "type": "FLOAT",
+          "widget": {
+            "name": "cfg"
+          },
+          "link": 1506
+        },
+        {
+          "label": "CFGLow",
+          "name": "cfg_1",
+          "type": "FLOAT",
+          "widget": {
+            "name": "cfg_1"
+          },
+          "link": 1509
+        }
+      ],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": [
+            1433
+          ]
+        }
+      ],
+      "properties": {
+        "proxyWidgets": [
+          [
+            "1040",
+            "value"
+          ],
+          [
+            "1041",
+            "length"
+          ],
+          [
+            "1039",
+            "cfg"
+          ],
+          [
+            "1042",
+            "cfg"
+          ]
+        ],
+        "cnr_id": "comfy-core",
+        "ver": "0.22.0",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "input_ue_unconnectable": {},
+          "version": "7.8"
+        }
+      },
+      "widgets_values": [],
+      "color": "#432",
+      "bgcolor": "#653"
+    },
+    {
+      "id": 1094,
+      "type": "ImageBatchExtendWithOverlap",
+      "pos": [
+        805.8627424963032,
+        -167.28552055118254
+      ],
+      "size": [
+        321.6236328125,
+        146
+      ],
+      "flags": {},
+      "order": 123,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "source_images",
+          "type": "IMAGE",
+          "link": 1432
+        },
+        {
+          "name": "new_images",
+          "shape": 7,
+          "type": "IMAGE",
+          "link": 1431
+        }
+      ],
+      "outputs": [
+        {
+          "name": "source_images",
+          "type": "IMAGE",
+          "links": []
+        },
+        {
+          "name": "start_images",
+          "type": "IMAGE",
+          "links": []
+        },
+        {
+          "name": "extended_images",
+          "type": "IMAGE",
+          "links": [
+            1430
+          ]
+        }
+      ],
+      "title": "Merge Pass 3 (chain)",
+      "properties": {
+        "cnr_id": "comfyui-kjnodes",
+        "ver": "79f529a84a8c20fe5dcdfa984c6be7a94102c014",
+        "Node name for S&R": "ImageBatchExtendWithOverlap",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        },
+        "aux_id": "kijai/ComfyUI-KJNodes"
+      },
+      "widgets_values": [
+        5,
+        "source",
+        "linear_blend"
+      ]
+    },
+    {
+      "id": 1110,
+      "type": "VRAM_Debug",
+      "pos": [
+        811.5623633990313,
+        109.59525110561722
+      ],
+      "size": [
+        306.9609375,
+        186
+      ],
+      "flags": {},
+      "order": 127,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "any_input",
+          "shape": 7,
+          "type": "*",
+          "link": null
+        },
+        {
+          "name": "image_pass",
+          "shape": 7,
+          "type": "IMAGE",
+          "link": 1463
+        },
+        {
+          "name": "model_pass",
+          "shape": 7,
+          "type": "MODEL",
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "any_output",
+          "type": "*",
+          "links": null
+        },
+        {
+          "name": "image_pass",
+          "type": "IMAGE",
+          "links": [
+            1523,
+            1525
+          ]
+        },
+        {
+          "name": "model_pass",
+          "type": "MODEL",
+          "links": null
+        },
+        {
+          "label": "21,057,867,416   freemem_before",
+          "name": "freemem_before",
+          "type": "INT",
+          "links": null
+        },
+        {
+          "label": "80,020,458,430      freemem_after",
+          "name": "freemem_after",
+          "type": "INT",
+          "links": null
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfyui-kjnodes",
+        "ver": "204f6d5aae73b10c0fe2fb26e61405fd6337bb77",
+        "Node name for S&R": "VRAM_Debug",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "input_ue_unconnectable": {},
+          "version": "7.8"
+        }
+      },
+      "widgets_values": [
+        true,
+        true,
+        true
+      ]
+    },
+    {
+      "id": 964,
+      "type": "bd9d3c66-e1a6-4739-ab20-46bf80f5ed01",
+      "pos": [
+        488.2814635741347,
+        -371.74692014354326
+      ],
+      "size": [
+        210,
+        370
+      ],
+      "flags": {},
+      "order": 110,
+      "mode": 0,
+      "inputs": [
+        {
+          "label": "high_model",
+          "name": "model_1",
+          "type": "MODEL",
+          "link": 1389
+        },
+        {
+          "name": "vae",
+          "type": "VAE",
+          "link": 1205
+        },
+        {
+          "label": "low_model",
+          "name": "model_2",
+          "type": "MODEL",
+          "link": 1390
+        },
+        {
+          "name": "positive",
+          "type": "CONDITIONING",
+          "link": 1207
+        },
+        {
+          "name": "negative",
+          "type": "CONDITIONING",
+          "link": 1208
+        },
+        {
+          "name": "anchor_samples",
+          "type": "LATENT",
+          "link": 1209
+        },
+        {
+          "name": "prev_samples",
+          "shape": 7,
+          "type": "LATENT",
+          "link": 1225
+        },
+        {
+          "label": "seed",
+          "name": "value",
+          "type": "INT",
+          "widget": {
+            "name": "value"
+          },
+          "link": 1265
+        },
+        {
+          "label": "SamplerHigh",
+          "name": "sampler",
+          "type": "SAMPLER",
+          "link": 1443
+        },
+        {
+          "label": "sigmas_high",
+          "name": "sigmas",
+          "type": "SIGMAS",
+          "link": 1354
+        },
+        {
+          "label": "sigmas_low",
+          "name": "sigmas_1",
+          "type": "SIGMAS",
+          "link": 1355
+        },
+        {
+          "name": "length",
+          "type": "INT",
+          "widget": {
+            "name": "length"
+          },
+          "link": 1356
+        },
+        {
+          "label": "SamplerLow",
+          "name": "sampler_1",
+          "type": "SAMPLER",
+          "link": 1499
+        },
+        {
+          "label": "CFGHigh",
+          "name": "cfg",
+          "type": "FLOAT",
+          "widget": {
+            "name": "cfg"
+          },
+          "link": 1500
+        },
+        {
+          "label": "CFGLow",
+          "name": "cfg_1",
+          "type": "FLOAT",
+          "widget": {
+            "name": "cfg_1"
+          },
+          "link": 1502
+        }
+      ],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": [
+            1211
+          ]
+        },
+        {
+          "name": "LATENT",
+          "type": "LATENT",
+          "links": [
+            1391
+          ]
+        }
+      ],
+      "properties": {
+        "proxyWidgets": [
+          [
+            "981",
+            "value"
+          ],
+          [
+            "1010",
+            "length"
+          ],
+          [
+            "1009",
+            "cfg"
+          ],
+          [
+            "1012",
+            "cfg"
+          ]
+        ],
+        "cnr_id": "comfy-core",
+        "ver": "0.22.0",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "input_ue_unconnectable": {},
+          "version": "7.8"
+        }
+      },
+      "widgets_values": [],
+      "color": "#432",
+      "bgcolor": "#653"
+    },
+    {
+      "id": 1038,
+      "type": "acc3a0bf-63ed-4f19-ba5a-b8ea4cdcdc87",
+      "pos": [
+        499.00820424557975,
+        230.7629230271209
+      ],
+      "size": [
+        210,
+        370
+      ],
+      "flags": {},
+      "order": 119,
+      "mode": 0,
+      "inputs": [
+        {
+          "label": "high_model",
+          "name": "model_1",
+          "type": "MODEL",
+          "link": 1436
+        },
+        {
+          "name": "vae",
+          "type": "VAE",
+          "link": 1397
+        },
+        {
+          "label": "low_model",
+          "name": "model_2",
+          "type": "MODEL",
+          "link": 1437
+        },
+        {
+          "name": "positive",
+          "type": "CONDITIONING",
+          "link": 1399
+        },
+        {
+          "name": "negative",
+          "type": "CONDITIONING",
+          "link": 1400
+        },
+        {
+          "name": "anchor_samples",
+          "type": "LATENT",
+          "link": 1398
+        },
+        {
+          "name": "prev_samples",
+          "shape": 7,
+          "type": "LATENT",
+          "link": 1391
+        },
+        {
+          "label": "seed",
+          "name": "value",
+          "type": "INT",
+          "widget": {
+            "name": "value"
+          },
+          "link": 1402
+        },
+        {
+          "label": "SamplerHigh",
+          "name": "sampler",
+          "type": "SAMPLER",
+          "link": 1404
+        },
+        {
+          "label": "sigmas_high",
+          "name": "sigmas",
+          "type": "SIGMAS",
+          "link": 1428
+        },
+        {
+          "label": "sigmas_low",
+          "name": "sigmas_1",
+          "type": "SIGMAS",
+          "link": 1429
+        },
+        {
+          "name": "length",
+          "type": "INT",
+          "widget": {
+            "name": "length"
+          },
+          "link": 1401
+        },
+        {
+          "label": "SamplerLow",
+          "name": "sampler_1",
+          "type": "SAMPLER",
+          "link": 1504
+        },
+        {
+          "label": "CFGHigh",
+          "name": "cfg",
+          "type": "FLOAT",
+          "widget": {
+            "name": "cfg"
+          },
+          "link": 1507
+        },
+        {
+          "label": "CFGLow",
+          "name": "cfg_1",
+          "type": "FLOAT",
+          "widget": {
+            "name": "cfg_1"
+          },
+          "link": 1508
+        }
+      ],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": [
+            1431
+          ]
+        },
+        {
+          "name": "LATENT",
+          "type": "LATENT",
+          "links": [
+            1392
+          ]
+        }
+      ],
+      "properties": {
+        "proxyWidgets": [
+          [
+            "1034",
+            "value"
+          ],
+          [
+            "1035",
+            "length"
+          ],
+          [
+            "1033",
+            "cfg"
+          ],
+          [
+            "1036",
+            "cfg"
+          ]
+        ],
+        "cnr_id": "comfy-core",
+        "ver": "0.22.0",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "input_ue_unconnectable": {},
+          "version": "7.8"
+        }
+      },
+      "widgets_values": [],
+      "color": "#432",
+      "bgcolor": "#653"
+    },
+    {
+      "id": 965,
+      "type": "5039141f-3a4c-4bb0-ab99-08a1c26e5177",
+      "pos": [
+        477.38548141440896,
+        -953.3283060018629
+      ],
+      "size": [
+        210,
+        358
+      ],
+      "flags": {},
+      "order": 87,
+      "mode": 0,
+      "inputs": [
+        {
+          "label": "high_model",
+          "name": "model_1",
+          "type": "MODEL",
+          "link": 1217
+        },
+        {
+          "name": "vae",
+          "type": "VAE",
+          "link": 1219
+        },
+        {
+          "label": "low_model",
+          "name": "model_2",
+          "type": "MODEL",
+          "link": 1220
+        },
+        {
+          "name": "positive",
+          "type": "CONDITIONING",
+          "link": 1221
+        },
+        {
+          "name": "negative",
+          "type": "CONDITIONING",
+          "link": 1222
+        },
+        {
+          "name": "anchor_samples",
+          "type": "LATENT",
+          "link": 1223
+        },
+        {
+          "name": "length",
+          "type": "INT",
+          "widget": {
+            "name": "length"
+          },
+          "link": 1232
+        },
+        {
+          "label": "seed",
+          "name": "value",
+          "type": "INT",
+          "widget": {
+            "name": "value"
+          },
+          "link": 1266
+        },
+        {
+          "label": "SamplerHigh",
+          "name": "sampler",
+          "type": "SAMPLER",
+          "link": 1442
+        },
+        {
+          "label": "high_sigmas",
+          "name": "sigmas",
+          "type": "SIGMAS",
+          "link": 1352
+        },
+        {
+          "label": "low_sigmas",
+          "name": "sigmas_1",
+          "type": "SIGMAS",
+          "link": 1353
+        },
+        {
+          "label": "CFG_High",
+          "name": "cfg",
+          "type": "FLOAT",
+          "widget": {
+            "name": "cfg"
+          },
+          "link": 1501
+        },
+        {
+          "label": "CFG_Low",
+          "name": "cfg_1",
+          "type": "FLOAT",
+          "widget": {
+            "name": "cfg_1"
+          },
+          "link": 1503
+        },
+        {
+          "label": "SamplerLow",
+          "name": "sampler_1",
+          "type": "SAMPLER",
+          "link": 1486
+        }
+      ],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": [
+            1224
+          ]
+        },
+        {
+          "name": "LATENT",
+          "type": "LATENT",
+          "links": [
+            1225
+          ]
+        }
+      ],
+      "properties": {
+        "proxyWidgets": [
+          [
+            "893",
+            "length"
+          ],
+          [
+            "980",
+            "value"
+          ],
+          [
+            "1006",
+            "cfg"
+          ],
+          [
+            "1007",
+            "cfg"
+          ]
+        ],
+        "cnr_id": "comfy-core",
+        "ver": "0.22.0",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "input_ue_unconnectable": {},
+          "version": "7.8"
+        }
+      },
+      "widgets_values": [],
+      "color": "#432",
+      "bgcolor": "#653"
+    },
+    {
+      "id": 1005,
+      "type": "WanMoEScheduler",
+      "pos": [
+        -3135.1634463016608,
+        -570.6336769404944
+      ],
+      "size": [
+        270,
+        298
+      ],
+      "flags": {},
+      "order": 83,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "model",
+          "type": "MODEL",
+          "link": 1473
+        }
+      ],
+      "outputs": [
+        {
+          "name": "shift",
+          "type": "FLOAT",
+          "links": [
+            1292
+          ]
+        },
+        {
+          "name": "steps",
+          "type": "INT",
+          "links": []
+        },
+        {
+          "name": "steps_high",
+          "type": "INT",
+          "links": []
+        },
+        {
+          "name": "steps_low",
+          "type": "INT",
+          "links": null
+        },
+        {
+          "name": "sigmas",
+          "type": "SIGMAS",
+          "links": null
+        },
+        {
+          "name": "sigmas_high",
+          "type": "SIGMAS",
+          "links": [
+            1350
+          ]
+        },
+        {
+          "name": "sigmas_low",
+          "type": "SIGMAS",
+          "links": [
+            1351
+          ]
+        }
+      ],
+      "title": "WanMoESchedulerHigh",
+      "properties": {
+        "cnr_id": "wanmoescheduler",
+        "ver": "1.0.0",
+        "Node name for S&R": "WanMoEScheduler",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.1",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "beta",
+        4,
+        4,
+        0.9,
+        0.01,
+        1
+      ]
+    },
+    {
+      "id": 883,
+      "type": "LoraLoaderModelOnly",
+      "pos": [
+        -2746.6947809341855,
+        -414.7821010350591
+      ],
+      "size": [
+        381.8711403358735,
+        83.01525597994748
+      ],
+      "flags": {},
+      "order": 121,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "model",
+          "type": "MODEL",
+          "link": 1007
+        }
+      ],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": [
+            1009
+          ]
+        }
+      ],
+      "title": "Lightning high LoRA",
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.8.0",
+        "Node name for S&R": "LoraLoaderModelOnly",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "i2v_lightx2v_high_noise_model.safetensors",
+        1
+      ],
+      "color": "#223",
+      "bgcolor": "#335"
+    },
+    {
+      "id": 884,
+      "type": "LoraLoaderModelOnly",
+      "pos": [
+        -2753.817710621685,
+        -75.85667134755909
+      ],
+      "size": [
+        385.8691344794463,
+        82
+      ],
+      "flags": {},
+      "order": 117,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "model",
+          "type": "MODEL",
+          "link": 1011
+        }
+      ],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": [
+            1012
+          ]
+        }
+      ],
+      "title": "Lightning low LoRA",
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.8.0",
+        "Node name for S&R": "LoraLoaderModelOnly",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        "i2v_lightx2v_low_noise_model.safetensors",
+        1
+      ],
+      "color": "#223",
+      "bgcolor": "#335"
+    },
+    {
+      "id": 1131,
+      "type": "Float",
+      "pos": [
+        -705.9659572913691,
+        -514.3876135068468
+      ],
+      "size": [
+        270,
+        58
+      ],
+      "flags": {},
+      "order": 67,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "FLOAT",
+          "type": "FLOAT",
+          "links": [
+            1488
+          ]
+        }
+      ],
+      "title": "CFGLow",
+      "properties": {
+        "cnr_id": "ComfyLiterals",
+        "ver": "bdddb08ca82d90d75d97b1d437a652e0284a32ac",
+        "Node name for S&R": "Float",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "input_ue_unconnectable": {},
+          "version": "7.8"
+        }
+      },
+      "widgets_values": [
+        "1"
+      ],
+      "color": "#232",
+      "bgcolor": "#353"
+    },
+    {
+      "id": 1119,
+      "type": "KSamplerSelect",
+      "pos": [
+        -271.19516634443744,
+        -563.270625748608
+      ],
+      "size": [
+        270,
+        58
+      ],
+      "flags": {},
+      "order": 68,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "SAMPLER",
+          "type": "SAMPLER",
+          "links": [
+            1481
+          ]
+        }
+      ],
+      "title": "KSamplerLow",
+      "properties": {
+        "cnr_id": "comfy-core",
+        "ver": "0.24.0",
+        "Node name for S&R": "KSamplerSelect",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "input_ue_unconnectable": {},
+          "version": "7.8"
+        }
+      },
+      "widgets_values": [
+        "euler"
+      ],
+      "color": "#232",
+      "bgcolor": "#353"
+    },
+    {
+      "id": 966,
+      "type": "INTConstant",
+      "pos": [
+        -259.49723112101356,
+        -863.8807233741429
+      ],
+      "size": [
+        252.7926605935387,
+        58
+      ],
+      "flags": {
+        "collapsed": false
+      },
+      "order": 69,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "value",
+          "type": "INT",
+          "links": [
+            1230
+          ]
+        }
+      ],
+      "title": "Segment Length (in frames)",
+      "properties": {
+        "cnr_id": "comfyui-kjnodes",
+        "ver": "487c7d86a0230aae3d8c0a37d517159b73834f85",
+        "Node name for S&R": "INTConstant",
+        "ue_properties": {
+          "widget_ue_connectable": {},
+          "version": "7.8",
+          "input_ue_unconnectable": {}
+        }
+      },
+      "widgets_values": [
+        81
+      ],
+      "color": "#232",
+      "bgcolor": "#353"
+    }
+  ],
+  "links": [
+    [
+      1003,
+      224,
+      0,
+      354,
+      0,
+      "CLIP"
+    ],
+    [
+      1004,
+      225,
+      0,
+      352,
+      0,
+      "VAE"
+    ],
+    [
+      1006,
+      880,
+      0,
+      881,
+      0,
+      "MODEL"
+    ],
+    [
+      1007,
+      881,
+      0,
+      883,
+      0,
+      "MODEL"
+    ],
+    [
+      1009,
+      883,
+      0,
+      358,
+      0,
+      "MODEL"
+    ],
+    [
+      1011,
+      882,
+      0,
+      884,
+      0,
+      "MODEL"
+    ],
+    [
+      1012,
+      884,
+      0,
+      357,
+      0,
+      "MODEL"
+    ],
+    [
+      1013,
+      62,
+      0,
+      887,
+      0,
+      "IMAGE"
+    ],
+    [
+      1014,
+      887,
+      0,
+      138,
+      0,
+      "IMAGE"
+    ],
+    [
+      1015,
+      137,
+      0,
+      891,
+      0,
+      "CLIP"
+    ],
+    [
+      1016,
+      137,
+      0,
+      892,
+      0,
+      "CLIP"
+    ],
+    [
+      1021,
+      139,
+      0,
+      896,
+      0,
+      "IMAGE"
+    ],
+    [
+      1022,
+      131,
+      0,
+      896,
+      1,
+      "VAE"
+    ],
+    [
+      1023,
+      896,
+      0,
+      145,
+      0,
+      "LATENT"
+    ],
+    [
+      1160,
+      950,
+      0,
+      891,
+      1,
+      "STRING"
+    ],
+    [
+      1161,
+      951,
+      0,
+      892,
+      1,
+      "STRING"
+    ],
+    [
+      1162,
+      891,
+      0,
+      952,
+      0,
+      "CONDITIONING"
+    ],
+    [
+      1163,
+      892,
+      0,
+      953,
+      0,
+      "CONDITIONING"
+    ],
+    [
+      1205,
+      197,
+      0,
+      964,
+      1,
+      "VAE"
+    ],
+    [
+      1207,
+      954,
+      0,
+      964,
+      3,
+      "CONDITIONING"
+    ],
+    [
+      1208,
+      960,
+      0,
+      964,
+      4,
+      "CONDITIONING"
+    ],
+    [
+      1209,
+      200,
+      0,
+      964,
+      5,
+      "LATENT"
+    ],
+    [
+      1211,
+      964,
+      0,
+      906,
+      1,
+      "IMAGE"
+    ],
+    [
+      1217,
+      411,
+      0,
+      965,
+      0,
+      "MODEL"
+    ],
+    [
+      1219,
+      130,
+      0,
+      965,
+      1,
+      "VAE"
+    ],
+    [
+      1220,
+      412,
+      0,
+      965,
+      2,
+      "MODEL"
+    ],
+    [
+      1221,
+      955,
+      0,
+      965,
+      3,
+      "CONDITIONING"
+    ],
+    [
+      1222,
+      961,
+      0,
+      965,
+      4,
+      "CONDITIONING"
+    ],
+    [
+      1223,
+      146,
+      0,
+      965,
+      5,
+      "LATENT"
+    ],
+    [
+      1224,
+      965,
+      0,
+      906,
+      0,
+      "IMAGE"
+    ],
+    [
+      1225,
+      965,
+      1,
+      964,
+      6,
+      "LATENT"
+    ],
+    [
+      1230,
+      966,
+      0,
+      967,
+      0,
+      "INT"
+    ],
+    [
+      1232,
+      969,
+      0,
+      965,
+      6,
+      "INT"
+    ],
+    [
+      1263,
+      984,
+      0,
+      985,
+      0,
+      "INT"
+    ],
+    [
+      1265,
+      986,
+      0,
+      964,
+      7,
+      "INT"
+    ],
+    [
+      1266,
+      987,
+      0,
+      965,
+      7,
+      "INT"
+    ],
+    [
+      1272,
+      990,
+      0,
+      993,
+      1,
+      "STRING"
+    ],
+    [
+      1276,
+      993,
+      0,
+      998,
+      0,
+      "CONDITIONING"
+    ],
+    [
+      1277,
+      137,
+      0,
+      993,
+      0,
+      "CLIP"
+    ],
+    [
+      1290,
+      1004,
+      0,
+      882,
+      0,
+      "MODEL"
+    ],
+    [
+      1292,
+      1005,
+      0,
+      880,
+      1,
+      "FLOAT"
+    ],
+    [
+      1350,
+      1005,
+      5,
+      1013,
+      0,
+      "SIGMAS"
+    ],
+    [
+      1351,
+      1005,
+      6,
+      1014,
+      0,
+      "SIGMAS"
+    ],
+    [
+      1352,
+      1015,
+      0,
+      965,
+      9,
+      "SIGMAS"
+    ],
+    [
+      1353,
+      1016,
+      0,
+      965,
+      10,
+      "SIGMAS"
+    ],
+    [
+      1354,
+      1015,
+      0,
+      964,
+      9,
+      "SIGMAS"
+    ],
+    [
+      1355,
+      1016,
+      0,
+      964,
+      10,
+      "SIGMAS"
+    ],
+    [
+      1356,
+      968,
+      0,
+      964,
+      11,
+      "INT"
+    ],
+    [
+      1381,
+      1022,
+      0,
+      1026,
+      0,
+      "MODEL"
+    ],
+    [
+      1382,
+      1021,
+      0,
+      1025,
+      0,
+      "MODEL"
+    ],
+    [
+      1383,
+      1023,
+      0,
+      1027,
+      0,
+      "MODEL"
+    ],
+    [
+      1384,
+      1024,
+      0,
+      1028,
+      0,
+      "MODEL"
+    ],
+    [
+      1386,
+      1029,
+      0,
+      1022,
+      0,
+      "MODEL"
+    ],
+    [
+      1388,
+      1030,
+      0,
+      1021,
+      0,
+      "MODEL"
+    ],
+    [
+      1389,
+      1031,
+      0,
+      964,
+      0,
+      "MODEL"
+    ],
+    [
+      1390,
+      1032,
+      0,
+      964,
+      2,
+      "MODEL"
+    ],
+    [
+      1391,
+      964,
+      1,
+      1038,
+      6,
+      "LATENT"
+    ],
+    [
+      1392,
+      1038,
+      1,
+      1044,
+      6,
+      "LATENT"
+    ],
+    [
+      1393,
+      1050,
+      0,
+      1045,
+      1,
+      "STRING"
+    ],
+    [
+      1394,
+      1049,
+      0,
+      1046,
+      1,
+      "STRING"
+    ],
+    [
+      1395,
+      1045,
+      0,
+      1047,
+      0,
+      "CONDITIONING"
+    ],
+    [
+      1396,
+      1046,
+      0,
+      1048,
+      0,
+      "CONDITIONING"
+    ],
+    [
+      1397,
+      1058,
+      0,
+      1038,
+      1,
+      "VAE"
+    ],
+    [
+      1398,
+      1059,
+      0,
+      1038,
+      5,
+      "LATENT"
+    ],
+    [
+      1399,
+      1075,
+      0,
+      1038,
+      3,
+      "CONDITIONING"
+    ],
+    [
+      1400,
+      1071,
+      0,
+      1038,
+      4,
+      "CONDITIONING"
+    ],
+    [
+      1401,
+      1072,
+      0,
+      1038,
+      11,
+      "INT"
+    ],
+    [
+      1402,
+      1077,
+      0,
+      1038,
+      7,
+      "INT"
+    ],
+    [
+      1403,
+      1008,
+      0,
+      1078,
+      0,
+      "SAMPLER"
+    ],
+    [
+      1404,
+      1079,
+      0,
+      1038,
+      8,
+      "SAMPLER"
+    ],
+    [
+      1405,
+      1079,
+      0,
+      1044,
+      8,
+      "SAMPLER"
+    ],
+    [
+      1406,
+      1068,
+      0,
+      1044,
+      5,
+      "LATENT"
+    ],
+    [
+      1407,
+      1067,
+      0,
+      1044,
+      1,
+      "VAE"
+    ],
+    [
+      1408,
+      1076,
+      0,
+      1044,
+      3,
+      "CONDITIONING"
+    ],
+    [
+      1409,
+      1069,
+      0,
+      1044,
+      4,
+      "CONDITIONING"
+    ],
+    [
+      1410,
+      1073,
+      0,
+      1044,
+      11,
+      "INT"
+    ],
+    [
+      1411,
+      1074,
+      0,
+      1044,
+      7,
+      "INT"
+    ],
+    [
+      1412,
+      1083,
+      0,
+      1081,
+      0,
+      "MODEL"
+    ],
+    [
+      1413,
+      1082,
+      0,
+      1084,
+      0,
+      "MODEL"
+    ],
+    [
+      1414,
+      1086,
+      0,
+      1089,
+      0,
+      "MODEL"
+    ],
+    [
+      1415,
+      1087,
+      0,
+      1088,
+      0,
+      "MODEL"
+    ],
+    [
+      1417,
+      1029,
+      0,
+      1082,
+      0,
+      "MODEL"
+    ],
+    [
+      1419,
+      1030,
+      0,
+      1083,
+      0,
+      "MODEL"
+    ],
+    [
+      1420,
+      1090,
+      0,
+      1086,
+      0,
+      "MODEL"
+    ],
+    [
+      1421,
+      1090,
+      0,
+      1023,
+      0,
+      "MODEL"
+    ],
+    [
+      1422,
+      1091,
+      0,
+      1087,
+      0,
+      "MODEL"
+    ],
+    [
+      1423,
+      1091,
+      0,
+      1024,
+      0,
+      "MODEL"
+    ],
+    [
+      1424,
+      1080,
+      0,
+      1044,
+      0,
+      "MODEL"
+    ],
+    [
+      1425,
+      1064,
+      0,
+      1044,
+      2,
+      "MODEL"
+    ],
+    [
+      1426,
+      1092,
+      0,
+      1044,
+      9,
+      "SIGMAS"
+    ],
+    [
+      1427,
+      1093,
+      0,
+      1044,
+      10,
+      "SIGMAS"
+    ],
+    [
+      1428,
+      1092,
+      0,
+      1038,
+      9,
+      "SIGMAS"
+    ],
+    [
+      1429,
+      1093,
+      0,
+      1038,
+      10,
+      "SIGMAS"
+    ],
+    [
+      1430,
+      1094,
+      2,
+      1095,
+      0,
+      "IMAGE"
+    ],
+    [
+      1431,
+      1038,
+      0,
+      1094,
+      1,
+      "IMAGE"
+    ],
+    [
+      1432,
+      906,
+      2,
+      1094,
+      0,
+      "IMAGE"
+    ],
+    [
+      1433,
+      1044,
+      0,
+      1095,
+      1,
+      "IMAGE"
+    ],
+    [
+      1436,
+      1097,
+      0,
+      1038,
+      0,
+      "MODEL"
+    ],
+    [
+      1437,
+      1096,
+      0,
+      1038,
+      2,
+      "MODEL"
+    ],
+    [
+      1438,
+      137,
+      0,
+      1046,
+      0,
+      "CLIP"
+    ],
+    [
+      1439,
+      137,
+      0,
+      1045,
+      0,
+      "CLIP"
+    ],
+    [
+      1442,
+      1098,
+      0,
+      965,
+      8,
+      "SAMPLER"
+    ],
+    [
+      1443,
+      1098,
+      0,
+      964,
+      8,
+      "SAMPLER"
+    ],
+    [
+      1457,
+      62,
+      0,
+      1109,
+      0,
+      "IMAGE"
+    ],
+    [
+      1458,
+      1108,
+      0,
+      1109,
+      1,
+      "INT"
+    ],
+    [
+      1459,
+      1107,
+      0,
+      1109,
+      2,
+      "INT"
+    ],
+    [
+      1460,
+      1109,
+      0,
+      887,
+      2,
+      "INT"
+    ],
+    [
+      1461,
+      1109,
+      1,
+      887,
+      3,
+      "INT"
+    ],
+    [
+      1463,
+      1095,
+      2,
+      1110,
+      1,
+      "IMAGE"
+    ],
+    [
+      1465,
+      1095,
+      2,
+      1111,
+      0,
+      "IMAGE"
+    ],
+    [
+      1473,
+      1002,
+      0,
+      1005,
+      0,
+      "MODEL"
+    ],
+    [
+      1474,
+      1002,
+      0,
+      880,
+      0,
+      "MODEL"
+    ],
+    [
+      1475,
+      1003,
+      0,
+      1004,
+      0,
+      "MODEL"
+    ],
+    [
+      1481,
+      1119,
+      0,
+      1120,
+      0,
+      "SAMPLER"
+    ],
+    [
+      1486,
+      1128,
+      0,
+      965,
+      13,
+      "SAMPLER"
+    ],
+    [
+      1487,
+      1130,
+      0,
+      1132,
+      0,
+      "FLOAT"
+    ],
+    [
+      1488,
+      1131,
+      0,
+      1133,
+      0,
+      "FLOAT"
+    ],
+    [
+      1499,
+      1128,
+      0,
+      964,
+      12,
+      "SAMPLER"
+    ],
+    [
+      1500,
+      1134,
+      0,
+      964,
+      13,
+      "FLOAT"
+    ],
+    [
+      1501,
+      1134,
+      0,
+      965,
+      11,
+      "FLOAT"
+    ],
+    [
+      1502,
+      1135,
+      0,
+      964,
+      14,
+      "FLOAT"
+    ],
+    [
+      1503,
+      1135,
+      0,
+      965,
+      12,
+      "FLOAT"
+    ],
+    [
+      1504,
+      1138,
+      0,
+      1038,
+      12,
+      "SAMPLER"
+    ],
+    [
+      1505,
+      1138,
+      0,
+      1044,
+      12,
+      "SAMPLER"
+    ],
+    [
+      1506,
+      1136,
+      0,
+      1044,
+      13,
+      "FLOAT"
+    ],
+    [
+      1507,
+      1136,
+      0,
+      1038,
+      13,
+      "FLOAT"
+    ],
+    [
+      1508,
+      1137,
+      0,
+      1038,
+      14,
+      "FLOAT"
+    ],
+    [
+      1509,
+      1137,
+      0,
+      1044,
+      14,
+      "FLOAT"
+    ],
+    [
+      1523,
+      1110,
+      1,
+      512,
+      0,
+      "IMAGE"
+    ],
+    [
+      1525,
+      1110,
+      1,
+      1151,
+      0,
+      "IMAGE"
+    ],
+    [
+      1527,
+      1151,
+      0,
+      1117,
+      0,
+      "IMAGE"
+    ],
+    [
+      1528,
+      1151,
+      0,
+      1118,
+      0,
+      "IMAGE"
+    ]
+  ],
+  "groups": [
+    {
+      "id": 1,
+      "title": "Model Loaders",
+      "bounding": [
+        -3502.46593135137,
+        -709.8396478545895,
+        1190.1318968363275,
+        814.6820812078126
+      ],
+      "color": "#b58b2a",
+      "flags": {}
+    },
+    {
+      "id": 4,
+      "title": "Global Settings",
+      "bounding": [
+        -976.2699382434266,
+        -1374.0300509868212,
+        1019.5259551562499,
+        1087.2941275781252
+      ],
+      "color": "#ff5900",
+      "flags": {}
+    },
+    {
+      "id": 5,
+      "title": "1st Pass",
+      "bounding": [
+        61.32305293952665,
+        -1135.8354040974907,
+        3861.4296293452367,
+        2486.1887511938244
+      ],
+      "color": "#3f789e",
+      "flags": {}
+    },
+    {
+      "id": 6,
+      "title": "Prompts Per Segment",
+      "bounding": [
+        -975.6945581257585,
+        -273.9880584305987,
+        1023.42064265625,
+        822.3088541406252
+      ],
+      "color": "#ff5900",
+      "flags": {}
+    },
+    {
+      "id": 7,
+      "title": "Per-Segment LoRA Loader",
+      "bounding": [
+        -2297.0894741478432,
+        -996.949959530263,
+        1307.385154334765,
+        1636.834632611719
+      ],
+      "color": "#b58b2a",
+      "flags": {}
+    },
+    {
+      "id": 8,
+      "title": "Segment 1 LoRAs",
+      "bounding": [
+        -2285.9266757150876,
+        -932.9784348916224,
+        538.0524191573536,
+        655.8846150509485
+      ],
+      "color": "#A88",
+      "flags": {}
+    },
+    {
+      "id": 9,
+      "title": "Segment 2 LoRAs",
+      "bounding": [
+        -1530.9794722072563,
+        -928.6265142512998,
+        513.7200754073531,
+        637.5885642696984
+      ],
+      "color": "#A88",
+      "flags": {}
+    },
+    {
+      "id": 10,
+      "title": "Segment 3 LoRAs",
+      "bounding": [
+        -2275.5115566782974,
+        -177.89675815110826,
+        538.0524191573536,
+        655.8846150509485
+      ],
+      "color": "#A88",
+      "flags": {}
+    },
+    {
+      "id": 11,
+      "title": "Segment 4 LoRAs",
+      "bounding": [
+        -1553.2087412346496,
+        -173.40350147415572,
+        538.0524191573536,
+        655.8846150509485
+      ],
+      "color": "#A88",
+      "flags": {}
+    }
+  ],
+  "definitions": {
+    "subgraphs": [
+      {
+        "id": "bd9d3c66-e1a6-4739-ab20-46bf80f5ed01",
+        "version": 1,
+        "state": {
+          "lastGroupId": 12,
+          "lastNodeId": 1151,
+          "lastLinkId": 1529,
+          "lastRerouteId": 0
+        },
+        "revision": 0,
+        "config": {},
+        "name": "Pass 2",
+        "inputNode": {
+          "id": -10,
+          "bounding": [
+            256.8059805957757,
+            -472.10846008186286,
+            140.1328125,
+            348
+          ]
+        },
+        "outputNode": {
+          "id": -20,
+          "bounding": [
+            1693.9600298964788,
+            -357.3593221311205,
+            128,
+            88
+          ]
+        },
+        "inputs": [
+          {
+            "id": "5a17fa42-6be3-40ac-a4cb-0fef77c4bfbb",
+            "name": "model_1",
+            "type": "MODEL",
+            "linkIds": [
+              1338
+            ],
+            "localized_name": "model_1",
+            "label": "high_model",
+            "pos": [
+              372.9387930957757,
+              -448.10846008186286
+            ]
+          },
+          {
+            "id": "ecbc448c-b0ca-47e7-b5e6-c7b7b376a133",
+            "name": "vae",
+            "type": "VAE",
+            "linkIds": [
+              1077
+            ],
+            "localized_name": "vae",
+            "pos": [
+              372.9387930957757,
+              -428.10846008186286
+            ]
+          },
+          {
+            "id": "8ca8a2f1-ca65-41c4-9de2-84355a107a3a",
+            "name": "model_2",
+            "type": "MODEL",
+            "linkIds": [
+              1339
+            ],
+            "localized_name": "model_2",
+            "label": "low_model",
+            "pos": [
+              372.9387930957757,
+              -408.10846008186286
+            ]
+          },
+          {
+            "id": "255d2dc4-b00b-44ce-8959-6cf717a6f9d4",
+            "name": "positive",
+            "type": "CONDITIONING",
+            "linkIds": [
+              1336
+            ],
+            "localized_name": "positive",
+            "pos": [
+              372.9387930957757,
+              -388.10846008186286
+            ]
+          },
+          {
+            "id": "72081130-160d-49d4-b48e-a18a04564063",
+            "name": "negative",
+            "type": "CONDITIONING",
+            "linkIds": [
+              1335
+            ],
+            "localized_name": "negative",
+            "pos": [
+              372.9387930957757,
+              -368.10846008186286
+            ]
+          },
+          {
+            "id": "74ae0c79-c7b2-4b0e-a1f1-8429faf5e5f8",
+            "name": "anchor_samples",
+            "type": "LATENT",
+            "linkIds": [
+              1334
+            ],
+            "localized_name": "anchor_samples",
+            "pos": [
+              372.9387930957757,
+              -348.10846008186286
+            ]
+          },
+          {
+            "id": "d0f22315-c8f7-4069-b473-6df7fb6fe583",
+            "name": "prev_samples",
+            "type": "LATENT",
+            "linkIds": [
+              1333
+            ],
+            "localized_name": "prev_samples",
+            "shape": 7,
+            "pos": [
+              372.9387930957757,
+              -328.10846008186286
+            ]
+          },
+          {
+            "id": "4cabdbda-b400-46e1-b96b-94111207b6ac",
+            "name": "value",
+            "type": "INT",
+            "linkIds": [
+              1254
+            ],
+            "label": "seed",
+            "pos": [
+              372.9387930957757,
+              -308.10846008186286
+            ]
+          },
+          {
+            "id": "7ee1fcce-4c78-4c03-ae32-89b95c445274",
+            "name": "sampler",
+            "type": "SAMPLER",
+            "linkIds": [
+              1358
+            ],
+            "label": "SamplerHigh",
+            "pos": [
+              372.9387930957757,
+              -288.10846008186286
+            ]
+          },
+          {
+            "id": "b4f99bc9-4d6f-43f3-ac51-1828f77dfd57",
+            "name": "sigmas",
+            "type": "SIGMAS",
+            "linkIds": [
+              1341
+            ],
+            "label": "sigmas_high",
+            "pos": [
+              372.9387930957757,
+              -268.10846008186286
+            ]
+          },
+          {
+            "id": "5a07c4c7-fdfb-4b89-aacf-44db8455dd2f",
+            "name": "sigmas_1",
+            "type": "SIGMAS",
+            "linkIds": [
+              1342
+            ],
+            "label": "sigmas_low",
+            "pos": [
+              372.9387930957757,
+              -248.10846008186286
+            ]
+          },
+          {
+            "id": "5a4f7c6e-c737-42e5-9a36-de39b4840e1e",
+            "name": "length",
+            "type": "INT",
+            "linkIds": [
+              1348
+            ],
+            "pos": [
+              372.9387930957757,
+              -228.10846008186286
+            ]
+          },
+          {
+            "id": "f3a4d788-f41f-4db1-af78-8384fa2a1c8a",
+            "name": "sampler_1",
+            "type": "SAMPLER",
+            "linkIds": [
+              1489
+            ],
+            "label": "SamplerLow",
+            "pos": [
+              372.9387930957757,
+              -208.10846008186286
+            ]
+          },
+          {
+            "id": "fbe944f5-f3f4-46f5-99f7-461a6e32ec96",
+            "name": "cfg",
+            "type": "FLOAT",
+            "linkIds": [
+              1490
+            ],
+            "label": "CFGHigh",
+            "pos": [
+              372.9387930957757,
+              -188.10846008186286
+            ]
+          },
+          {
+            "id": "9468294b-b5a9-4002-b939-a5481f1fb10c",
+            "name": "cfg_1",
+            "type": "FLOAT",
+            "linkIds": [
+              1491
+            ],
+            "label": "CFGLow",
+            "pos": [
+              372.9387930957757,
+              -168.10846008186286
+            ]
+          }
+        ],
+        "outputs": [
+          {
+            "id": "44b51028-4e5c-4cfb-9629-a1be70fda9e7",
+            "name": "IMAGE",
+            "type": "IMAGE",
+            "linkIds": [
+              1078
+            ],
+            "localized_name": "IMAGE",
+            "pos": [
+              1717.9600298964788,
+              -333.3593221311205
+            ]
+          },
+          {
+            "id": "60a30e11-303b-4b4e-a0af-d68b2e33f7b4",
+            "name": "LATENT",
+            "type": "LATENT",
+            "linkIds": [
+              1441
+            ],
+            "localized_name": "LATENT",
+            "pos": [
+              1717.9600298964788,
+              -313.3593221311205
+            ]
+          }
+        ],
+        "widgets": [],
+        "nodes": [
+          {
+            "id": 981,
+            "type": "PrimitiveInt",
+            "pos": [
+              469.9587399007141,
+              -223.05038117995394
+            ],
+            "size": [
+              270,
+              82
+            ],
+            "flags": {},
+            "order": 1,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "value",
+                "name": "value",
+                "type": "INT",
+                "widget": {
+                  "name": "value"
+                },
+                "link": 1254
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "INT",
+                "name": "INT",
+                "type": "INT",
+                "links": [
+                  1345,
+                  1346
+                ]
+              }
+            ],
+            "properties": {
+              "cnr_id": "comfy-core",
+              "ver": "0.22.0",
+              "Node name for S&R": "PrimitiveInt",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "input_ue_unconnectable": {},
+                "version": "7.8"
+              }
+            },
+            "widgets_values": [
+              0,
+              "fixed"
+            ]
+          },
+          {
+            "id": 1010,
+            "type": "WanImageToVideoSVIPro",
+            "pos": [
+              468.4210583738685,
+              -435.6195722807448
+            ],
+            "size": [
+              277.80078125,
+              142
+            ],
+            "flags": {},
+            "order": 3,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "positive",
+                "name": "positive",
+                "type": "CONDITIONING",
+                "link": 1336
+              },
+              {
+                "localized_name": "negative",
+                "name": "negative",
+                "type": "CONDITIONING",
+                "link": 1335
+              },
+              {
+                "localized_name": "anchor_samples",
+                "name": "anchor_samples",
+                "type": "LATENT",
+                "link": 1334
+              },
+              {
+                "localized_name": "prev_samples",
+                "name": "prev_samples",
+                "shape": 7,
+                "type": "LATENT",
+                "link": 1333
+              },
+              {
+                "localized_name": "length",
+                "name": "length",
+                "type": "INT",
+                "widget": {
+                  "name": "length"
+                },
+                "link": 1348
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "positive",
+                "name": "positive",
+                "type": "CONDITIONING",
+                "links": [
+                  1325,
+                  1329
+                ]
+              },
+              {
+                "localized_name": "negative",
+                "name": "negative",
+                "type": "CONDITIONING",
+                "links": [
+                  1326,
+                  1330
+                ]
+              },
+              {
+                "localized_name": "latent",
+                "name": "latent",
+                "type": "LATENT",
+                "links": [
+                  1373
+                ]
+              }
+            ],
+            "title": "Pass 2 SVI latent",
+            "properties": {
+              "cnr_id": "comfyui-kjnodes",
+              "ver": "7b1327192e4729085788a3020a9cbb095e0c7811",
+              "Node name for S&R": "WanImageToVideoSVIPro",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              }
+            },
+            "widgets_values": [
+              81,
+              1
+            ]
+          },
+          {
+            "id": 913,
+            "type": "VAEDecode",
+            "pos": [
+              1467.5817848648687,
+              -361.87007866819795
+            ],
+            "size": [
+              140,
+              48.621998838299646
+            ],
+            "flags": {
+              "collapsed": false
+            },
+            "order": 0,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "samples",
+                "name": "samples",
+                "type": "LATENT",
+                "link": 1344
+              },
+              {
+                "localized_name": "vae",
+                "name": "vae",
+                "type": "VAE",
+                "link": 1077
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "IMAGE",
+                "name": "IMAGE",
+                "type": "IMAGE",
+                "slot_index": 0,
+                "links": [
+                  1078
+                ]
+              }
+            ],
+            "title": "Decode Pass 2",
+            "properties": {
+              "cnr_id": "comfy-core",
+              "ver": "0.3.45",
+              "Node name for S&R": "VAEDecode",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              }
+            },
+            "widgets_values": []
+          },
+          {
+            "id": 1009,
+            "type": "SamplerCustom",
+            "pos": [
+              800.900686407553,
+              -414.6088522909141
+            ],
+            "size": [
+              271.125,
+              230
+            ],
+            "flags": {},
+            "order": 2,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "model",
+                "name": "model",
+                "type": "MODEL",
+                "link": 1338
+              },
+              {
+                "localized_name": "positive",
+                "name": "positive",
+                "type": "CONDITIONING",
+                "link": 1325
+              },
+              {
+                "localized_name": "negative",
+                "name": "negative",
+                "type": "CONDITIONING",
+                "link": 1326
+              },
+              {
+                "localized_name": "sampler",
+                "name": "sampler",
+                "type": "SAMPLER",
+                "link": 1358
+              },
+              {
+                "localized_name": "sigmas",
+                "name": "sigmas",
+                "type": "SIGMAS",
+                "link": 1341
+              },
+              {
+                "localized_name": "latent_image",
+                "name": "latent_image",
+                "type": "LATENT",
+                "link": 1373
+              },
+              {
+                "localized_name": "noise_seed",
+                "name": "noise_seed",
+                "type": "INT",
+                "widget": {
+                  "name": "noise_seed"
+                },
+                "link": 1345
+              },
+              {
+                "localized_name": "cfg",
+                "name": "cfg",
+                "type": "FLOAT",
+                "widget": {
+                  "name": "cfg"
+                },
+                "link": 1490
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "output",
+                "name": "output",
+                "type": "LATENT",
+                "links": [
+                  1331
+                ]
+              },
+              {
+                "localized_name": "denoised_output",
+                "name": "denoised_output",
+                "type": "LATENT",
+                "links": []
+              }
+            ],
+            "properties": {
+              "cnr_id": "comfy-core",
+              "ver": "0.24.0",
+              "Node name for S&R": "SamplerCustom",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "input_ue_unconnectable": {},
+                "version": "7.8"
+              }
+            },
+            "widgets_values": [
+              true,
+              492987193200532,
+              "randomize",
+              1
+            ]
+          },
+          {
+            "id": 1012,
+            "type": "SamplerCustom",
+            "pos": [
+              1113.3513818908227,
+              -409.15720446498244
+            ],
+            "size": [
+              271.125,
+              230
+            ],
+            "flags": {},
+            "order": 4,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "model",
+                "name": "model",
+                "type": "MODEL",
+                "link": 1339
+              },
+              {
+                "localized_name": "positive",
+                "name": "positive",
+                "type": "CONDITIONING",
+                "link": 1329
+              },
+              {
+                "localized_name": "negative",
+                "name": "negative",
+                "type": "CONDITIONING",
+                "link": 1330
+              },
+              {
+                "localized_name": "sampler",
+                "name": "sampler",
+                "type": "SAMPLER",
+                "link": 1489
+              },
+              {
+                "localized_name": "sigmas",
+                "name": "sigmas",
+                "type": "SIGMAS",
+                "link": 1342
+              },
+              {
+                "localized_name": "latent_image",
+                "name": "latent_image",
+                "type": "LATENT",
+                "link": 1331
+              },
+              {
+                "localized_name": "noise_seed",
+                "name": "noise_seed",
+                "type": "INT",
+                "widget": {
+                  "name": "noise_seed"
+                },
+                "link": 1346
+              },
+              {
+                "localized_name": "cfg",
+                "name": "cfg",
+                "type": "FLOAT",
+                "widget": {
+                  "name": "cfg"
+                },
+                "link": 1491
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "output",
+                "name": "output",
+                "type": "LATENT",
+                "links": [
+                  1441
+                ]
+              },
+              {
+                "localized_name": "denoised_output",
+                "name": "denoised_output",
+                "type": "LATENT",
+                "links": [
+                  1344
+                ]
+              }
+            ],
+            "properties": {
+              "cnr_id": "comfy-core",
+              "ver": "0.24.0",
+              "Node name for S&R": "SamplerCustom",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "input_ue_unconnectable": {},
+                "version": "7.8"
+              }
+            },
+            "widgets_values": [
+              false,
+              978225129631471,
+              "randomize",
+              1
+            ]
+          }
+        ],
+        "groups": [],
+        "links": [
+          {
+            "id": 1077,
+            "origin_id": -10,
+            "origin_slot": 1,
+            "target_id": 913,
+            "target_slot": 1,
+            "type": "VAE"
+          },
+          {
+            "id": 1078,
+            "origin_id": 913,
+            "origin_slot": 0,
+            "target_id": -20,
+            "target_slot": 0,
+            "type": "IMAGE"
+          },
+          {
+            "id": 1254,
+            "origin_id": -10,
+            "origin_slot": 7,
+            "target_id": 981,
+            "target_slot": 0,
+            "type": "INT"
+          },
+          {
+            "id": 1325,
+            "origin_id": 1010,
+            "origin_slot": 0,
+            "target_id": 1009,
+            "target_slot": 1,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 1326,
+            "origin_id": 1010,
+            "origin_slot": 1,
+            "target_id": 1009,
+            "target_slot": 2,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 1329,
+            "origin_id": 1010,
+            "origin_slot": 0,
+            "target_id": 1012,
+            "target_slot": 1,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 1330,
+            "origin_id": 1010,
+            "origin_slot": 1,
+            "target_id": 1012,
+            "target_slot": 2,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 1331,
+            "origin_id": 1009,
+            "origin_slot": 0,
+            "target_id": 1012,
+            "target_slot": 5,
+            "type": "LATENT"
+          },
+          {
+            "id": 1333,
+            "origin_id": -10,
+            "origin_slot": 6,
+            "target_id": 1010,
+            "target_slot": 3,
+            "type": "LATENT"
+          },
+          {
+            "id": 1334,
+            "origin_id": -10,
+            "origin_slot": 5,
+            "target_id": 1010,
+            "target_slot": 2,
+            "type": "LATENT"
+          },
+          {
+            "id": 1335,
+            "origin_id": -10,
+            "origin_slot": 4,
+            "target_id": 1010,
+            "target_slot": 1,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 1336,
+            "origin_id": -10,
+            "origin_slot": 3,
+            "target_id": 1010,
+            "target_slot": 0,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 1338,
+            "origin_id": -10,
+            "origin_slot": 0,
+            "target_id": 1009,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 1339,
+            "origin_id": -10,
+            "origin_slot": 2,
+            "target_id": 1012,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 1341,
+            "origin_id": -10,
+            "origin_slot": 9,
+            "target_id": 1009,
+            "target_slot": 4,
+            "type": "SIGMAS"
+          },
+          {
+            "id": 1342,
+            "origin_id": -10,
+            "origin_slot": 10,
+            "target_id": 1012,
+            "target_slot": 4,
+            "type": "SIGMAS"
+          },
+          {
+            "id": 1344,
+            "origin_id": 1012,
+            "origin_slot": 1,
+            "target_id": 913,
+            "target_slot": 0,
+            "type": "LATENT"
+          },
+          {
+            "id": 1345,
+            "origin_id": 981,
+            "origin_slot": 0,
+            "target_id": 1009,
+            "target_slot": 6,
+            "type": "INT"
+          },
+          {
+            "id": 1346,
+            "origin_id": 981,
+            "origin_slot": 0,
+            "target_id": 1012,
+            "target_slot": 6,
+            "type": "INT"
+          },
+          {
+            "id": 1348,
+            "origin_id": -10,
+            "origin_slot": 11,
+            "target_id": 1010,
+            "target_slot": 4,
+            "type": "INT"
+          },
+          {
+            "id": 1358,
+            "origin_id": -10,
+            "origin_slot": 8,
+            "target_id": 1009,
+            "target_slot": 3,
+            "type": "SAMPLER"
+          },
+          {
+            "id": 1373,
+            "origin_id": 1010,
+            "origin_slot": 2,
+            "target_id": 1009,
+            "target_slot": 5,
+            "type": "LATENT"
+          },
+          {
+            "id": 1441,
+            "origin_id": 1012,
+            "origin_slot": 0,
+            "target_id": -20,
+            "target_slot": 1,
+            "type": "LATENT"
+          },
+          {
+            "id": 1489,
+            "origin_id": -10,
+            "origin_slot": 12,
+            "target_id": 1012,
+            "target_slot": 3,
+            "type": "SAMPLER"
+          },
+          {
+            "id": 1490,
+            "origin_id": -10,
+            "origin_slot": 13,
+            "target_id": 1009,
+            "target_slot": 7,
+            "type": "FLOAT"
+          },
+          {
+            "id": 1491,
+            "origin_id": -10,
+            "origin_slot": 14,
+            "target_id": 1012,
+            "target_slot": 7,
+            "type": "FLOAT"
+          }
+        ],
+        "extra": {
+          "ue_links": [],
+          "links_added_by_ue": []
+        }
+      },
+      {
+        "id": "5039141f-3a4c-4bb0-ab99-08a1c26e5177",
+        "version": 1,
+        "state": {
+          "lastGroupId": 12,
+          "lastNodeId": 1151,
+          "lastLinkId": 1529,
+          "lastRerouteId": 0
+        },
+        "revision": 0,
+        "config": {},
+        "name": "Pass 1",
+        "inputNode": {
+          "id": -10,
+          "bounding": [
+            216.50231075202674,
+            -893.7298845662382,
+            140.1328125,
+            328
+          ]
+        },
+        "outputNode": {
+          "id": -20,
+          "bounding": [
+            1660.6655773475086,
+            -796.0922856933579,
+            128,
+            88
+          ]
+        },
+        "inputs": [
+          {
+            "id": "811e4a5a-0b0b-4dc5-bdc8-6b4c8ae1dc35",
+            "name": "model_1",
+            "type": "MODEL",
+            "linkIds": [
+              1302
+            ],
+            "localized_name": "model_1",
+            "label": "high_model",
+            "pos": [
+              332.63512325202674,
+              -869.7298845662382
+            ]
+          },
+          {
+            "id": "6ece64bf-4600-43b0-989d-d13a3f1c3b46",
+            "name": "vae",
+            "type": "VAE",
+            "linkIds": [
+              1097
+            ],
+            "localized_name": "vae",
+            "pos": [
+              332.63512325202674,
+              -849.7298845662382
+            ]
+          },
+          {
+            "id": "f7bb1021-2b8d-4bbf-9910-3b42b8e7ddb1",
+            "name": "model_2",
+            "type": "MODEL",
+            "linkIds": [
+              1303
+            ],
+            "localized_name": "model_2",
+            "label": "low_model",
+            "pos": [
+              332.63512325202674,
+              -829.7298845662382
+            ]
+          },
+          {
+            "id": "6b4a4c27-b40f-4bbc-884a-9d5f37ee01fb",
+            "name": "positive",
+            "type": "CONDITIONING",
+            "linkIds": [
+              1165
+            ],
+            "localized_name": "positive",
+            "pos": [
+              332.63512325202674,
+              -809.7298845662382
+            ]
+          },
+          {
+            "id": "fcb941d4-6d8a-49b8-97f4-630bb03e1d0d",
+            "name": "negative",
+            "type": "CONDITIONING",
+            "linkIds": [
+              1171
+            ],
+            "localized_name": "negative",
+            "pos": [
+              332.63512325202674,
+              -789.7298845662382
+            ]
+          },
+          {
+            "id": "85a8869e-40a7-4c8c-9c32-148ffcf8f309",
+            "name": "anchor_samples",
+            "type": "LATENT",
+            "linkIds": [
+              1035
+            ],
+            "localized_name": "anchor_samples",
+            "pos": [
+              332.63512325202674,
+              -769.7298845662382
+            ]
+          },
+          {
+            "id": "e5d686f0-dcf8-47a7-aba0-52b1df99695c",
+            "name": "length",
+            "type": "INT",
+            "linkIds": [
+              1227
+            ],
+            "pos": [
+              332.63512325202674,
+              -749.7298845662382
+            ]
+          },
+          {
+            "id": "a26552d2-68b1-48b8-b542-99e9cbeed135",
+            "name": "value",
+            "type": "INT",
+            "linkIds": [
+              1371
+            ],
+            "label": "seed",
+            "pos": [
+              332.63512325202674,
+              -729.7298845662382
+            ]
+          },
+          {
+            "id": "8758b9ee-1a48-497f-8465-10dd46cb8b1e",
+            "name": "sampler",
+            "type": "SAMPLER",
+            "linkIds": [
+              1295
+            ],
+            "label": "SamplerHigh",
+            "pos": [
+              332.63512325202674,
+              -709.7298845662382
+            ]
+          },
+          {
+            "id": "ea9cee6b-459c-4574-8e5e-f5167b66f61b",
+            "name": "sigmas",
+            "type": "SIGMAS",
+            "linkIds": [
+              1297
+            ],
+            "label": "high_sigmas",
+            "pos": [
+              332.63512325202674,
+              -689.7298845662382
+            ]
+          },
+          {
+            "id": "8b4f416e-ce1b-4d5c-b5f3-917b4c1baedc",
+            "name": "sigmas_1",
+            "type": "SIGMAS",
+            "linkIds": [
+              1298
+            ],
+            "label": "low_sigmas",
+            "pos": [
+              332.63512325202674,
+              -669.7298845662382
+            ]
+          },
+          {
+            "id": "6c544b01-56d6-421d-a281-d1de92bfb023",
+            "name": "cfg",
+            "type": "FLOAT",
+            "linkIds": [
+              1483
+            ],
+            "label": "CFG_High",
+            "pos": [
+              332.63512325202674,
+              -649.7298845662382
+            ]
+          },
+          {
+            "id": "e8d31844-27f2-41d7-a4b1-0aed2035a657",
+            "name": "cfg_1",
+            "type": "FLOAT",
+            "linkIds": [
+              1484
+            ],
+            "label": "CFG_Low",
+            "pos": [
+              332.63512325202674,
+              -629.7298845662382
+            ]
+          },
+          {
+            "id": "08a13958-d7f7-4b0a-a9bc-d80c46715657",
+            "name": "sampler_1",
+            "type": "SAMPLER",
+            "linkIds": [
+              1485
+            ],
+            "label": "SamplerLow",
+            "pos": [
+              332.63512325202674,
+              -609.7298845662382
+            ]
+          }
+        ],
+        "outputs": [
+          {
+            "id": "5374d541-18b2-40c5-a299-7e64fa94568a",
+            "name": "IMAGE",
+            "type": "IMAGE",
+            "linkIds": [
+              1098
+            ],
+            "localized_name": "IMAGE",
+            "pos": [
+              1684.6655773475086,
+              -772.0922856933579
+            ]
+          },
+          {
+            "id": "38016f22-49f7-481c-83f0-01b0efceb036",
+            "name": "LATENT",
+            "type": "LATENT",
+            "linkIds": [
+              1372
+            ],
+            "localized_name": "LATENT",
+            "pos": [
+              1684.6655773475086,
+              -752.0922856933579
+            ]
+          }
+        ],
+        "widgets": [],
+        "nodes": [
+          {
+            "id": 893,
+            "type": "WanImageToVideoSVIPro",
+            "pos": [
+              416.63512325202674,
+              -918.6478533162383
+            ],
+            "size": [
+              277.80078125,
+              142
+            ],
+            "flags": {},
+            "order": 0,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "positive",
+                "name": "positive",
+                "type": "CONDITIONING",
+                "link": 1165
+              },
+              {
+                "localized_name": "negative",
+                "name": "negative",
+                "type": "CONDITIONING",
+                "link": 1171
+              },
+              {
+                "localized_name": "anchor_samples",
+                "name": "anchor_samples",
+                "type": "LATENT",
+                "link": 1035
+              },
+              {
+                "localized_name": "prev_samples",
+                "name": "prev_samples",
+                "shape": 7,
+                "type": "LATENT",
+                "link": null
+              },
+              {
+                "localized_name": "length",
+                "name": "length",
+                "type": "INT",
+                "widget": {
+                  "name": "length"
+                },
+                "link": 1227
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "positive",
+                "name": "positive",
+                "type": "CONDITIONING",
+                "links": [
+                  1318,
+                  1321
+                ]
+              },
+              {
+                "localized_name": "negative",
+                "name": "negative",
+                "type": "CONDITIONING",
+                "links": [
+                  1316,
+                  1320
+                ]
+              },
+              {
+                "localized_name": "latent",
+                "name": "latent",
+                "type": "LATENT",
+                "links": [
+                  1374
+                ]
+              }
+            ],
+            "title": "Pass 1 SVI latent",
+            "properties": {
+              "cnr_id": "comfyui-kjnodes",
+              "ver": "7b1327192e4729085788a3020a9cbb095e0c7811",
+              "Node name for S&R": "WanImageToVideoSVIPro",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              }
+            },
+            "widgets_values": [
+              17,
+              0
+            ]
+          },
+          {
+            "id": 980,
+            "type": "PrimitiveInt",
+            "pos": [
+              417.0355831695139,
+              -731.1750490892406
+            ],
+            "size": [
+              270,
+              82
+            ],
+            "flags": {},
+            "order": 2,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "value",
+                "name": "value",
+                "type": "INT",
+                "widget": {
+                  "name": "value"
+                },
+                "link": 1371
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "INT",
+                "name": "INT",
+                "type": "INT",
+                "links": [
+                  1323,
+                  1324
+                ]
+              }
+            ],
+            "title": "seed",
+            "properties": {
+              "cnr_id": "comfy-core",
+              "ver": "0.22.0",
+              "Node name for S&R": "PrimitiveInt",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "input_ue_unconnectable": {},
+                "version": "7.8"
+              }
+            },
+            "widgets_values": [
+              33905770482576,
+              "randomize"
+            ]
+          },
+          {
+            "id": 898,
+            "type": "VAEDecode",
+            "pos": [
+              1436.1145310646134,
+              -783.2172470103992
+            ],
+            "size": [
+              140,
+              48.621998838299646
+            ],
+            "flags": {
+              "collapsed": false
+            },
+            "order": 1,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "samples",
+                "name": "samples",
+                "type": "LATENT",
+                "link": 1300
+              },
+              {
+                "localized_name": "vae",
+                "name": "vae",
+                "type": "VAE",
+                "link": 1097
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "IMAGE",
+                "name": "IMAGE",
+                "type": "IMAGE",
+                "slot_index": 0,
+                "links": [
+                  1098
+                ]
+              }
+            ],
+            "title": "Decode Pass 1",
+            "properties": {
+              "cnr_id": "comfy-core",
+              "ver": "0.3.45",
+              "Node name for S&R": "VAEDecode",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              }
+            },
+            "widgets_values": []
+          },
+          {
+            "id": 1006,
+            "type": "SamplerCustom",
+            "pos": [
+              786.2723684107488,
+              -880.8754314501409
+            ],
+            "size": [
+              271.125,
+              230
+            ],
+            "flags": {},
+            "order": 3,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "model",
+                "name": "model",
+                "type": "MODEL",
+                "link": 1302
+              },
+              {
+                "localized_name": "positive",
+                "name": "positive",
+                "type": "CONDITIONING",
+                "link": 1321
+              },
+              {
+                "localized_name": "negative",
+                "name": "negative",
+                "type": "CONDITIONING",
+                "link": 1320
+              },
+              {
+                "localized_name": "sampler",
+                "name": "sampler",
+                "type": "SAMPLER",
+                "link": 1295
+              },
+              {
+                "localized_name": "sigmas",
+                "name": "sigmas",
+                "type": "SIGMAS",
+                "link": 1297
+              },
+              {
+                "localized_name": "latent_image",
+                "name": "latent_image",
+                "type": "LATENT",
+                "link": 1374
+              },
+              {
+                "localized_name": "noise_seed",
+                "name": "noise_seed",
+                "type": "INT",
+                "widget": {
+                  "name": "noise_seed"
+                },
+                "link": 1323
+              },
+              {
+                "localized_name": "cfg",
+                "name": "cfg",
+                "type": "FLOAT",
+                "widget": {
+                  "name": "cfg"
+                },
+                "link": 1483
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "output",
+                "name": "output",
+                "type": "LATENT",
+                "links": [
+                  1301
+                ]
+              },
+              {
+                "localized_name": "denoised_output",
+                "name": "denoised_output",
+                "type": "LATENT",
+                "links": []
+              }
+            ],
+            "properties": {
+              "cnr_id": "comfy-core",
+              "ver": "0.24.0",
+              "Node name for S&R": "SamplerCustom",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "input_ue_unconnectable": {},
+                "version": "7.8"
+              }
+            },
+            "widgets_values": [
+              true,
+              584935344329580,
+              "randomize",
+              1
+            ]
+          },
+          {
+            "id": 1007,
+            "type": "SamplerCustom",
+            "pos": [
+              1098.7230638940182,
+              -875.4237836242092
+            ],
+            "size": [
+              271.125,
+              230
+            ],
+            "flags": {},
+            "order": 4,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "model",
+                "name": "model",
+                "type": "MODEL",
+                "link": 1303
+              },
+              {
+                "localized_name": "positive",
+                "name": "positive",
+                "type": "CONDITIONING",
+                "link": 1318
+              },
+              {
+                "localized_name": "negative",
+                "name": "negative",
+                "type": "CONDITIONING",
+                "link": 1316
+              },
+              {
+                "localized_name": "sampler",
+                "name": "sampler",
+                "type": "SAMPLER",
+                "link": 1485
+              },
+              {
+                "localized_name": "sigmas",
+                "name": "sigmas",
+                "type": "SIGMAS",
+                "link": 1298
+              },
+              {
+                "localized_name": "latent_image",
+                "name": "latent_image",
+                "type": "LATENT",
+                "link": 1301
+              },
+              {
+                "localized_name": "noise_seed",
+                "name": "noise_seed",
+                "type": "INT",
+                "widget": {
+                  "name": "noise_seed"
+                },
+                "link": 1324
+              },
+              {
+                "localized_name": "cfg",
+                "name": "cfg",
+                "type": "FLOAT",
+                "widget": {
+                  "name": "cfg"
+                },
+                "link": 1484
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "output",
+                "name": "output",
+                "type": "LATENT",
+                "links": [
+                  1372
+                ]
+              },
+              {
+                "localized_name": "denoised_output",
+                "name": "denoised_output",
+                "type": "LATENT",
+                "links": [
+                  1300
+                ]
+              }
+            ],
+            "properties": {
+              "cnr_id": "comfy-core",
+              "ver": "0.24.0",
+              "Node name for S&R": "SamplerCustom",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "input_ue_unconnectable": {},
+                "version": "7.8"
+              }
+            },
+            "widgets_values": [
+              false,
+              870906529905646,
+              "randomize",
+              1
+            ]
+          }
+        ],
+        "groups": [],
+        "links": [
+          {
+            "id": 1097,
+            "origin_id": -10,
+            "origin_slot": 1,
+            "target_id": 898,
+            "target_slot": 1,
+            "type": "VAE"
+          },
+          {
+            "id": 1165,
+            "origin_id": -10,
+            "origin_slot": 3,
+            "target_id": 893,
+            "target_slot": 0,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 1171,
+            "origin_id": -10,
+            "origin_slot": 4,
+            "target_id": 893,
+            "target_slot": 1,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 1035,
+            "origin_id": -10,
+            "origin_slot": 5,
+            "target_id": 893,
+            "target_slot": 2,
+            "type": "LATENT"
+          },
+          {
+            "id": 1098,
+            "origin_id": 898,
+            "origin_slot": 0,
+            "target_id": -20,
+            "target_slot": 0,
+            "type": "IMAGE"
+          },
+          {
+            "id": 1227,
+            "origin_id": -10,
+            "origin_slot": 6,
+            "target_id": 893,
+            "target_slot": 4,
+            "type": "INT"
+          },
+          {
+            "id": 1295,
+            "origin_id": -10,
+            "origin_slot": 8,
+            "target_id": 1006,
+            "target_slot": 3,
+            "type": "SAMPLER"
+          },
+          {
+            "id": 1297,
+            "origin_id": -10,
+            "origin_slot": 9,
+            "target_id": 1006,
+            "target_slot": 4,
+            "type": "SIGMAS"
+          },
+          {
+            "id": 1298,
+            "origin_id": -10,
+            "origin_slot": 10,
+            "target_id": 1007,
+            "target_slot": 4,
+            "type": "SIGMAS"
+          },
+          {
+            "id": 1300,
+            "origin_id": 1007,
+            "origin_slot": 1,
+            "target_id": 898,
+            "target_slot": 0,
+            "type": "LATENT"
+          },
+          {
+            "id": 1301,
+            "origin_id": 1006,
+            "origin_slot": 0,
+            "target_id": 1007,
+            "target_slot": 5,
+            "type": "LATENT"
+          },
+          {
+            "id": 1302,
+            "origin_id": -10,
+            "origin_slot": 0,
+            "target_id": 1006,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 1303,
+            "origin_id": -10,
+            "origin_slot": 2,
+            "target_id": 1007,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 1316,
+            "origin_id": 893,
+            "origin_slot": 1,
+            "target_id": 1007,
+            "target_slot": 2,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 1318,
+            "origin_id": 893,
+            "origin_slot": 0,
+            "target_id": 1007,
+            "target_slot": 1,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 1320,
+            "origin_id": 893,
+            "origin_slot": 1,
+            "target_id": 1006,
+            "target_slot": 2,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 1321,
+            "origin_id": 893,
+            "origin_slot": 0,
+            "target_id": 1006,
+            "target_slot": 1,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 1323,
+            "origin_id": 980,
+            "origin_slot": 0,
+            "target_id": 1006,
+            "target_slot": 6,
+            "type": "INT"
+          },
+          {
+            "id": 1324,
+            "origin_id": 980,
+            "origin_slot": 0,
+            "target_id": 1007,
+            "target_slot": 6,
+            "type": "INT"
+          },
+          {
+            "id": 1371,
+            "origin_id": -10,
+            "origin_slot": 7,
+            "target_id": 980,
+            "target_slot": 0,
+            "type": "INT"
+          },
+          {
+            "id": 1372,
+            "origin_id": 1007,
+            "origin_slot": 0,
+            "target_id": -20,
+            "target_slot": 1,
+            "type": "LATENT"
+          },
+          {
+            "id": 1374,
+            "origin_id": 893,
+            "origin_slot": 2,
+            "target_id": 1006,
+            "target_slot": 5,
+            "type": "LATENT"
+          },
+          {
+            "id": 1483,
+            "origin_id": -10,
+            "origin_slot": 11,
+            "target_id": 1006,
+            "target_slot": 7,
+            "type": "FLOAT"
+          },
+          {
+            "id": 1484,
+            "origin_id": -10,
+            "origin_slot": 12,
+            "target_id": 1007,
+            "target_slot": 7,
+            "type": "FLOAT"
+          },
+          {
+            "id": 1485,
+            "origin_id": -10,
+            "origin_slot": 13,
+            "target_id": 1007,
+            "target_slot": 3,
+            "type": "SAMPLER"
+          }
+        ],
+        "extra": {
+          "ue_links": [],
+          "links_added_by_ue": []
+        }
+      },
+      {
+        "id": "acc3a0bf-63ed-4f19-ba5a-b8ea4cdcdc87",
+        "version": 1,
+        "state": {
+          "lastGroupId": 12,
+          "lastNodeId": 1151,
+          "lastLinkId": 1529,
+          "lastRerouteId": 0
+        },
+        "revision": 0,
+        "config": {},
+        "name": "Pass 3",
+        "inputNode": {
+          "id": -10,
+          "bounding": [
+            256.8059805957757,
+            -472.10846008186286,
+            140.1328125,
+            348
+          ]
+        },
+        "outputNode": {
+          "id": -20,
+          "bounding": [
+            1693.9600298964788,
+            -357.3593221311205,
+            128,
+            88
+          ]
+        },
+        "inputs": [
+          {
+            "id": "5a17fa42-6be3-40ac-a4cb-0fef77c4bfbb",
+            "name": "model_1",
+            "type": "MODEL",
+            "linkIds": [
+              1338
+            ],
+            "localized_name": "model_1",
+            "label": "high_model",
+            "pos": [
+              372.9387930957757,
+              -448.10846008186286
+            ]
+          },
+          {
+            "id": "ecbc448c-b0ca-47e7-b5e6-c7b7b376a133",
+            "name": "vae",
+            "type": "VAE",
+            "linkIds": [
+              1077
+            ],
+            "localized_name": "vae",
+            "pos": [
+              372.9387930957757,
+              -428.10846008186286
+            ]
+          },
+          {
+            "id": "8ca8a2f1-ca65-41c4-9de2-84355a107a3a",
+            "name": "model_2",
+            "type": "MODEL",
+            "linkIds": [
+              1339
+            ],
+            "localized_name": "model_2",
+            "label": "low_model",
+            "pos": [
+              372.9387930957757,
+              -408.10846008186286
+            ]
+          },
+          {
+            "id": "255d2dc4-b00b-44ce-8959-6cf717a6f9d4",
+            "name": "positive",
+            "type": "CONDITIONING",
+            "linkIds": [
+              1336
+            ],
+            "localized_name": "positive",
+            "pos": [
+              372.9387930957757,
+              -388.10846008186286
+            ]
+          },
+          {
+            "id": "72081130-160d-49d4-b48e-a18a04564063",
+            "name": "negative",
+            "type": "CONDITIONING",
+            "linkIds": [
+              1335
+            ],
+            "localized_name": "negative",
+            "pos": [
+              372.9387930957757,
+              -368.10846008186286
+            ]
+          },
+          {
+            "id": "74ae0c79-c7b2-4b0e-a1f1-8429faf5e5f8",
+            "name": "anchor_samples",
+            "type": "LATENT",
+            "linkIds": [
+              1334
+            ],
+            "localized_name": "anchor_samples",
+            "pos": [
+              372.9387930957757,
+              -348.10846008186286
+            ]
+          },
+          {
+            "id": "d0f22315-c8f7-4069-b473-6df7fb6fe583",
+            "name": "prev_samples",
+            "type": "LATENT",
+            "linkIds": [
+              1333
+            ],
+            "localized_name": "prev_samples",
+            "shape": 7,
+            "pos": [
+              372.9387930957757,
+              -328.10846008186286
+            ]
+          },
+          {
+            "id": "4cabdbda-b400-46e1-b96b-94111207b6ac",
+            "name": "value",
+            "type": "INT",
+            "linkIds": [
+              1254
+            ],
+            "label": "seed",
+            "pos": [
+              372.9387930957757,
+              -308.10846008186286
+            ]
+          },
+          {
+            "id": "7ee1fcce-4c78-4c03-ae32-89b95c445274",
+            "name": "sampler",
+            "type": "SAMPLER",
+            "linkIds": [
+              1358
+            ],
+            "label": "SamplerHigh",
+            "pos": [
+              372.9387930957757,
+              -288.10846008186286
+            ]
+          },
+          {
+            "id": "b4f99bc9-4d6f-43f3-ac51-1828f77dfd57",
+            "name": "sigmas",
+            "type": "SIGMAS",
+            "linkIds": [
+              1341
+            ],
+            "label": "sigmas_high",
+            "pos": [
+              372.9387930957757,
+              -268.10846008186286
+            ]
+          },
+          {
+            "id": "5a07c4c7-fdfb-4b89-aacf-44db8455dd2f",
+            "name": "sigmas_1",
+            "type": "SIGMAS",
+            "linkIds": [
+              1342
+            ],
+            "label": "sigmas_low",
+            "pos": [
+              372.9387930957757,
+              -248.10846008186286
+            ]
+          },
+          {
+            "id": "5a4f7c6e-c737-42e5-9a36-de39b4840e1e",
+            "name": "length",
+            "type": "INT",
+            "linkIds": [
+              1348
+            ],
+            "pos": [
+              372.9387930957757,
+              -228.10846008186286
+            ]
+          },
+          {
+            "id": "433f12b2-e6f2-4b7c-a4a9-e0646b6edc32",
+            "name": "sampler_1",
+            "type": "SAMPLER",
+            "linkIds": [
+              1492
+            ],
+            "label": "SamplerLow",
+            "pos": [
+              372.9387930957757,
+              -208.10846008186286
+            ]
+          },
+          {
+            "id": "130896ff-a34b-45f2-bfc7-5b4774a36c49",
+            "name": "cfg",
+            "type": "FLOAT",
+            "linkIds": [
+              1493
+            ],
+            "label": "CFGHigh",
+            "pos": [
+              372.9387930957757,
+              -188.10846008186286
+            ]
+          },
+          {
+            "id": "33f79cd2-e574-432f-9549-64cf64bfb2c5",
+            "name": "cfg_1",
+            "type": "FLOAT",
+            "linkIds": [
+              1494
+            ],
+            "label": "CFGLow",
+            "pos": [
+              372.9387930957757,
+              -168.10846008186286
+            ]
+          }
+        ],
+        "outputs": [
+          {
+            "id": "44b51028-4e5c-4cfb-9629-a1be70fda9e7",
+            "name": "IMAGE",
+            "type": "IMAGE",
+            "linkIds": [
+              1078
+            ],
+            "localized_name": "IMAGE",
+            "pos": [
+              1717.9600298964788,
+              -333.3593221311205
+            ]
+          },
+          {
+            "id": "60a30e11-303b-4b4e-a0af-d68b2e33f7b4",
+            "name": "LATENT",
+            "type": "LATENT",
+            "linkIds": [
+              1440
+            ],
+            "localized_name": "LATENT",
+            "pos": [
+              1717.9600298964788,
+              -313.3593221311205
+            ]
+          }
+        ],
+        "widgets": [],
+        "nodes": [
+          {
+            "id": 1034,
+            "type": "PrimitiveInt",
+            "pos": [
+              469.9587399007141,
+              -223.05038117995394
+            ],
+            "size": [
+              270,
+              82
+            ],
+            "flags": {},
+            "order": 1,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "value",
+                "name": "value",
+                "type": "INT",
+                "widget": {
+                  "name": "value"
+                },
+                "link": 1254
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "INT",
+                "name": "INT",
+                "type": "INT",
+                "links": [
+                  1345,
+                  1346
+                ]
+              }
+            ],
+            "properties": {
+              "cnr_id": "comfy-core",
+              "ver": "0.22.0",
+              "Node name for S&R": "PrimitiveInt",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "input_ue_unconnectable": {},
+                "version": "7.8"
+              }
+            },
+            "widgets_values": [
+              0,
+              "fixed"
+            ]
+          },
+          {
+            "id": 1035,
+            "type": "WanImageToVideoSVIPro",
+            "pos": [
+              468.4210583738685,
+              -435.6195722807448
+            ],
+            "size": [
+              277.80078125,
+              142
+            ],
+            "flags": {},
+            "order": 2,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "positive",
+                "name": "positive",
+                "type": "CONDITIONING",
+                "link": 1336
+              },
+              {
+                "localized_name": "negative",
+                "name": "negative",
+                "type": "CONDITIONING",
+                "link": 1335
+              },
+              {
+                "localized_name": "anchor_samples",
+                "name": "anchor_samples",
+                "type": "LATENT",
+                "link": 1334
+              },
+              {
+                "localized_name": "prev_samples",
+                "name": "prev_samples",
+                "shape": 7,
+                "type": "LATENT",
+                "link": 1333
+              },
+              {
+                "localized_name": "length",
+                "name": "length",
+                "type": "INT",
+                "widget": {
+                  "name": "length"
+                },
+                "link": 1348
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "positive",
+                "name": "positive",
+                "type": "CONDITIONING",
+                "links": [
+                  1325,
+                  1329
+                ]
+              },
+              {
+                "localized_name": "negative",
+                "name": "negative",
+                "type": "CONDITIONING",
+                "links": [
+                  1326,
+                  1330
+                ]
+              },
+              {
+                "localized_name": "latent",
+                "name": "latent",
+                "type": "LATENT",
+                "links": [
+                  1373
+                ]
+              }
+            ],
+            "title": "Pass 2 SVI latent",
+            "properties": {
+              "cnr_id": "comfyui-kjnodes",
+              "ver": "7b1327192e4729085788a3020a9cbb095e0c7811",
+              "Node name for S&R": "WanImageToVideoSVIPro",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              }
+            },
+            "widgets_values": [
+              81,
+              1
+            ]
+          },
+          {
+            "id": 1037,
+            "type": "VAEDecode",
+            "pos": [
+              1467.5817848648687,
+              -361.87007866819795
+            ],
+            "size": [
+              140,
+              48.621998838299646
+            ],
+            "flags": {
+              "collapsed": false
+            },
+            "order": 4,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "samples",
+                "name": "samples",
+                "type": "LATENT",
+                "link": 1344
+              },
+              {
+                "localized_name": "vae",
+                "name": "vae",
+                "type": "VAE",
+                "link": 1077
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "IMAGE",
+                "name": "IMAGE",
+                "type": "IMAGE",
+                "slot_index": 0,
+                "links": [
+                  1078
+                ]
+              }
+            ],
+            "title": "Decode Pass 2",
+            "properties": {
+              "cnr_id": "comfy-core",
+              "ver": "0.3.45",
+              "Node name for S&R": "VAEDecode",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              }
+            },
+            "widgets_values": []
+          },
+          {
+            "id": 1033,
+            "type": "SamplerCustom",
+            "pos": [
+              806.7507788983212,
+              -409.56737258442445
+            ],
+            "size": [
+              271.125,
+              230
+            ],
+            "flags": {},
+            "order": 0,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "model",
+                "name": "model",
+                "type": "MODEL",
+                "link": 1338
+              },
+              {
+                "localized_name": "positive",
+                "name": "positive",
+                "type": "CONDITIONING",
+                "link": 1325
+              },
+              {
+                "localized_name": "negative",
+                "name": "negative",
+                "type": "CONDITIONING",
+                "link": 1326
+              },
+              {
+                "localized_name": "sampler",
+                "name": "sampler",
+                "type": "SAMPLER",
+                "link": 1358
+              },
+              {
+                "localized_name": "sigmas",
+                "name": "sigmas",
+                "type": "SIGMAS",
+                "link": 1341
+              },
+              {
+                "localized_name": "latent_image",
+                "name": "latent_image",
+                "type": "LATENT",
+                "link": 1373
+              },
+              {
+                "localized_name": "noise_seed",
+                "name": "noise_seed",
+                "type": "INT",
+                "widget": {
+                  "name": "noise_seed"
+                },
+                "link": 1345
+              },
+              {
+                "localized_name": "cfg",
+                "name": "cfg",
+                "type": "FLOAT",
+                "widget": {
+                  "name": "cfg"
+                },
+                "link": 1493
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "output",
+                "name": "output",
+                "type": "LATENT",
+                "links": [
+                  1331
+                ]
+              },
+              {
+                "localized_name": "denoised_output",
+                "name": "denoised_output",
+                "type": "LATENT",
+                "links": []
+              }
+            ],
+            "properties": {
+              "cnr_id": "comfy-core",
+              "ver": "0.24.0",
+              "Node name for S&R": "SamplerCustom",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "input_ue_unconnectable": {},
+                "version": "7.8"
+              }
+            },
+            "widgets_values": [
+              true,
+              578411154670353,
+              "randomize",
+              1
+            ]
+          },
+          {
+            "id": 1036,
+            "type": "SamplerCustom",
+            "pos": [
+              1111.4169513072077,
+              -402.8391045749516
+            ],
+            "size": [
+              271.125,
+              230
+            ],
+            "flags": {},
+            "order": 3,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "model",
+                "name": "model",
+                "type": "MODEL",
+                "link": 1339
+              },
+              {
+                "localized_name": "positive",
+                "name": "positive",
+                "type": "CONDITIONING",
+                "link": 1329
+              },
+              {
+                "localized_name": "negative",
+                "name": "negative",
+                "type": "CONDITIONING",
+                "link": 1330
+              },
+              {
+                "localized_name": "sampler",
+                "name": "sampler",
+                "type": "SAMPLER",
+                "link": 1492
+              },
+              {
+                "localized_name": "sigmas",
+                "name": "sigmas",
+                "type": "SIGMAS",
+                "link": 1342
+              },
+              {
+                "localized_name": "latent_image",
+                "name": "latent_image",
+                "type": "LATENT",
+                "link": 1331
+              },
+              {
+                "localized_name": "noise_seed",
+                "name": "noise_seed",
+                "type": "INT",
+                "widget": {
+                  "name": "noise_seed"
+                },
+                "link": 1346
+              },
+              {
+                "localized_name": "cfg",
+                "name": "cfg",
+                "type": "FLOAT",
+                "widget": {
+                  "name": "cfg"
+                },
+                "link": 1494
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "output",
+                "name": "output",
+                "type": "LATENT",
+                "links": [
+                  1440
+                ]
+              },
+              {
+                "localized_name": "denoised_output",
+                "name": "denoised_output",
+                "type": "LATENT",
+                "links": [
+                  1344
+                ]
+              }
+            ],
+            "properties": {
+              "cnr_id": "comfy-core",
+              "ver": "0.24.0",
+              "Node name for S&R": "SamplerCustom",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "input_ue_unconnectable": {},
+                "version": "7.8"
+              }
+            },
+            "widgets_values": [
+              false,
+              954024687936050,
+              "randomize",
+              0.2
+            ]
+          }
+        ],
+        "groups": [],
+        "links": [
+          {
+            "id": 1077,
+            "origin_id": -10,
+            "origin_slot": 1,
+            "target_id": 1037,
+            "target_slot": 1,
+            "type": "VAE"
+          },
+          {
+            "id": 1078,
+            "origin_id": 1037,
+            "origin_slot": 0,
+            "target_id": -20,
+            "target_slot": 0,
+            "type": "IMAGE"
+          },
+          {
+            "id": 1254,
+            "origin_id": -10,
+            "origin_slot": 7,
+            "target_id": 1034,
+            "target_slot": 0,
+            "type": "INT"
+          },
+          {
+            "id": 1325,
+            "origin_id": 1035,
+            "origin_slot": 0,
+            "target_id": 1033,
+            "target_slot": 1,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 1326,
+            "origin_id": 1035,
+            "origin_slot": 1,
+            "target_id": 1033,
+            "target_slot": 2,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 1329,
+            "origin_id": 1035,
+            "origin_slot": 0,
+            "target_id": 1036,
+            "target_slot": 1,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 1330,
+            "origin_id": 1035,
+            "origin_slot": 1,
+            "target_id": 1036,
+            "target_slot": 2,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 1331,
+            "origin_id": 1033,
+            "origin_slot": 0,
+            "target_id": 1036,
+            "target_slot": 5,
+            "type": "LATENT"
+          },
+          {
+            "id": 1333,
+            "origin_id": -10,
+            "origin_slot": 6,
+            "target_id": 1035,
+            "target_slot": 3,
+            "type": "LATENT"
+          },
+          {
+            "id": 1334,
+            "origin_id": -10,
+            "origin_slot": 5,
+            "target_id": 1035,
+            "target_slot": 2,
+            "type": "LATENT"
+          },
+          {
+            "id": 1335,
+            "origin_id": -10,
+            "origin_slot": 4,
+            "target_id": 1035,
+            "target_slot": 1,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 1336,
+            "origin_id": -10,
+            "origin_slot": 3,
+            "target_id": 1035,
+            "target_slot": 0,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 1338,
+            "origin_id": -10,
+            "origin_slot": 0,
+            "target_id": 1033,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 1339,
+            "origin_id": -10,
+            "origin_slot": 2,
+            "target_id": 1036,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 1341,
+            "origin_id": -10,
+            "origin_slot": 9,
+            "target_id": 1033,
+            "target_slot": 4,
+            "type": "SIGMAS"
+          },
+          {
+            "id": 1342,
+            "origin_id": -10,
+            "origin_slot": 10,
+            "target_id": 1036,
+            "target_slot": 4,
+            "type": "SIGMAS"
+          },
+          {
+            "id": 1344,
+            "origin_id": 1036,
+            "origin_slot": 1,
+            "target_id": 1037,
+            "target_slot": 0,
+            "type": "LATENT"
+          },
+          {
+            "id": 1345,
+            "origin_id": 1034,
+            "origin_slot": 0,
+            "target_id": 1033,
+            "target_slot": 6,
+            "type": "INT"
+          },
+          {
+            "id": 1346,
+            "origin_id": 1034,
+            "origin_slot": 0,
+            "target_id": 1036,
+            "target_slot": 6,
+            "type": "INT"
+          },
+          {
+            "id": 1348,
+            "origin_id": -10,
+            "origin_slot": 11,
+            "target_id": 1035,
+            "target_slot": 4,
+            "type": "INT"
+          },
+          {
+            "id": 1358,
+            "origin_id": -10,
+            "origin_slot": 8,
+            "target_id": 1033,
+            "target_slot": 3,
+            "type": "SAMPLER"
+          },
+          {
+            "id": 1373,
+            "origin_id": 1035,
+            "origin_slot": 2,
+            "target_id": 1033,
+            "target_slot": 5,
+            "type": "LATENT"
+          },
+          {
+            "id": 1440,
+            "origin_id": 1036,
+            "origin_slot": 0,
+            "target_id": -20,
+            "target_slot": 1,
+            "type": "LATENT"
+          },
+          {
+            "id": 1492,
+            "origin_id": -10,
+            "origin_slot": 12,
+            "target_id": 1036,
+            "target_slot": 3,
+            "type": "SAMPLER"
+          },
+          {
+            "id": 1493,
+            "origin_id": -10,
+            "origin_slot": 13,
+            "target_id": 1033,
+            "target_slot": 7,
+            "type": "FLOAT"
+          },
+          {
+            "id": 1494,
+            "origin_id": -10,
+            "origin_slot": 14,
+            "target_id": 1036,
+            "target_slot": 7,
+            "type": "FLOAT"
+          }
+        ],
+        "extra": {
+          "ue_links": [],
+          "links_added_by_ue": []
+        }
+      },
+      {
+        "id": "85e58d71-a4c3-4d0b-bbc9-1cb3b2979700",
+        "version": 1,
+        "state": {
+          "lastGroupId": 12,
+          "lastNodeId": 1151,
+          "lastLinkId": 1529,
+          "lastRerouteId": 0
+        },
+        "revision": 0,
+        "config": {},
+        "name": "Pass 4",
+        "inputNode": {
+          "id": -10,
+          "bounding": [
+            256.8059805957757,
+            -472.10846008186286,
+            140.1328125,
+            348
+          ]
+        },
+        "outputNode": {
+          "id": -20,
+          "bounding": [
+            1693.9600298964788,
+            -357.3593221311205,
+            128,
+            68
+          ]
+        },
+        "inputs": [
+          {
+            "id": "5a17fa42-6be3-40ac-a4cb-0fef77c4bfbb",
+            "name": "model_1",
+            "type": "MODEL",
+            "linkIds": [
+              1338
+            ],
+            "localized_name": "model_1",
+            "label": "high_model",
+            "pos": [
+              372.9387930957757,
+              -448.10846008186286
+            ]
+          },
+          {
+            "id": "ecbc448c-b0ca-47e7-b5e6-c7b7b376a133",
+            "name": "vae",
+            "type": "VAE",
+            "linkIds": [
+              1077
+            ],
+            "localized_name": "vae",
+            "pos": [
+              372.9387930957757,
+              -428.10846008186286
+            ]
+          },
+          {
+            "id": "8ca8a2f1-ca65-41c4-9de2-84355a107a3a",
+            "name": "model_2",
+            "type": "MODEL",
+            "linkIds": [
+              1339
+            ],
+            "localized_name": "model_2",
+            "label": "low_model",
+            "pos": [
+              372.9387930957757,
+              -408.10846008186286
+            ]
+          },
+          {
+            "id": "255d2dc4-b00b-44ce-8959-6cf717a6f9d4",
+            "name": "positive",
+            "type": "CONDITIONING",
+            "linkIds": [
+              1336
+            ],
+            "localized_name": "positive",
+            "pos": [
+              372.9387930957757,
+              -388.10846008186286
+            ]
+          },
+          {
+            "id": "72081130-160d-49d4-b48e-a18a04564063",
+            "name": "negative",
+            "type": "CONDITIONING",
+            "linkIds": [
+              1335
+            ],
+            "localized_name": "negative",
+            "pos": [
+              372.9387930957757,
+              -368.10846008186286
+            ]
+          },
+          {
+            "id": "74ae0c79-c7b2-4b0e-a1f1-8429faf5e5f8",
+            "name": "anchor_samples",
+            "type": "LATENT",
+            "linkIds": [
+              1334
+            ],
+            "localized_name": "anchor_samples",
+            "pos": [
+              372.9387930957757,
+              -348.10846008186286
+            ]
+          },
+          {
+            "id": "d0f22315-c8f7-4069-b473-6df7fb6fe583",
+            "name": "prev_samples",
+            "type": "LATENT",
+            "linkIds": [
+              1333
+            ],
+            "localized_name": "prev_samples",
+            "shape": 7,
+            "pos": [
+              372.9387930957757,
+              -328.10846008186286
+            ]
+          },
+          {
+            "id": "4cabdbda-b400-46e1-b96b-94111207b6ac",
+            "name": "value",
+            "type": "INT",
+            "linkIds": [
+              1254
+            ],
+            "label": "seed",
+            "pos": [
+              372.9387930957757,
+              -308.10846008186286
+            ]
+          },
+          {
+            "id": "7ee1fcce-4c78-4c03-ae32-89b95c445274",
+            "name": "sampler",
+            "type": "SAMPLER",
+            "linkIds": [
+              1358
+            ],
+            "label": "SamplerHigh",
+            "pos": [
+              372.9387930957757,
+              -288.10846008186286
+            ]
+          },
+          {
+            "id": "b4f99bc9-4d6f-43f3-ac51-1828f77dfd57",
+            "name": "sigmas",
+            "type": "SIGMAS",
+            "linkIds": [
+              1341
+            ],
+            "label": "sigmas_high",
+            "pos": [
+              372.9387930957757,
+              -268.10846008186286
+            ]
+          },
+          {
+            "id": "5a07c4c7-fdfb-4b89-aacf-44db8455dd2f",
+            "name": "sigmas_1",
+            "type": "SIGMAS",
+            "linkIds": [
+              1342
+            ],
+            "label": "sigmas_low",
+            "pos": [
+              372.9387930957757,
+              -248.10846008186286
+            ]
+          },
+          {
+            "id": "5a4f7c6e-c737-42e5-9a36-de39b4840e1e",
+            "name": "length",
+            "type": "INT",
+            "linkIds": [
+              1348
+            ],
+            "pos": [
+              372.9387930957757,
+              -228.10846008186286
+            ]
+          },
+          {
+            "id": "2e542c1e-aaa5-4edb-b590-ceedcc301d2d",
+            "name": "sampler_1",
+            "type": "SAMPLER",
+            "linkIds": [
+              1496
+            ],
+            "label": "SamplerLow",
+            "pos": [
+              372.9387930957757,
+              -208.10846008186286
+            ]
+          },
+          {
+            "id": "5bafb87c-82a8-45a1-8f9c-bc11e2c156ad",
+            "name": "cfg",
+            "type": "FLOAT",
+            "linkIds": [
+              1497
+            ],
+            "label": "CFGHigh",
+            "pos": [
+              372.9387930957757,
+              -188.10846008186286
+            ]
+          },
+          {
+            "id": "e53b5df8-cfc6-49a7-b182-a9f61c03ea62",
+            "name": "cfg_1",
+            "type": "FLOAT",
+            "linkIds": [
+              1498
+            ],
+            "label": "CFGLow",
+            "pos": [
+              372.9387930957757,
+              -168.10846008186286
+            ]
+          }
+        ],
+        "outputs": [
+          {
+            "id": "44b51028-4e5c-4cfb-9629-a1be70fda9e7",
+            "name": "IMAGE",
+            "type": "IMAGE",
+            "linkIds": [
+              1078
+            ],
+            "localized_name": "IMAGE",
+            "pos": [
+              1717.9600298964788,
+              -333.3593221311205
+            ]
+          }
+        ],
+        "widgets": [],
+        "nodes": [
+          {
+            "id": 1040,
+            "type": "PrimitiveInt",
+            "pos": [
+              469.9587399007141,
+              -223.05038117995394
+            ],
+            "size": [
+              270,
+              82
+            ],
+            "flags": {},
+            "order": 1,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "value",
+                "name": "value",
+                "type": "INT",
+                "widget": {
+                  "name": "value"
+                },
+                "link": 1254
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "INT",
+                "name": "INT",
+                "type": "INT",
+                "links": [
+                  1345,
+                  1346
+                ]
+              }
+            ],
+            "properties": {
+              "cnr_id": "comfy-core",
+              "ver": "0.22.0",
+              "Node name for S&R": "PrimitiveInt",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "input_ue_unconnectable": {},
+                "version": "7.8"
+              }
+            },
+            "widgets_values": [
+              0,
+              "fixed"
+            ]
+          },
+          {
+            "id": 1041,
+            "type": "WanImageToVideoSVIPro",
+            "pos": [
+              468.4210583738685,
+              -435.6195722807448
+            ],
+            "size": [
+              277.80078125,
+              142
+            ],
+            "flags": {},
+            "order": 2,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "positive",
+                "name": "positive",
+                "type": "CONDITIONING",
+                "link": 1336
+              },
+              {
+                "localized_name": "negative",
+                "name": "negative",
+                "type": "CONDITIONING",
+                "link": 1335
+              },
+              {
+                "localized_name": "anchor_samples",
+                "name": "anchor_samples",
+                "type": "LATENT",
+                "link": 1334
+              },
+              {
+                "localized_name": "prev_samples",
+                "name": "prev_samples",
+                "shape": 7,
+                "type": "LATENT",
+                "link": 1333
+              },
+              {
+                "localized_name": "length",
+                "name": "length",
+                "type": "INT",
+                "widget": {
+                  "name": "length"
+                },
+                "link": 1348
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "positive",
+                "name": "positive",
+                "type": "CONDITIONING",
+                "links": [
+                  1325,
+                  1329
+                ]
+              },
+              {
+                "localized_name": "negative",
+                "name": "negative",
+                "type": "CONDITIONING",
+                "links": [
+                  1326,
+                  1330
+                ]
+              },
+              {
+                "localized_name": "latent",
+                "name": "latent",
+                "type": "LATENT",
+                "links": [
+                  1373
+                ]
+              }
+            ],
+            "title": "Pass 2 SVI latent",
+            "properties": {
+              "cnr_id": "comfyui-kjnodes",
+              "ver": "7b1327192e4729085788a3020a9cbb095e0c7811",
+              "Node name for S&R": "WanImageToVideoSVIPro",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              }
+            },
+            "widgets_values": [
+              81,
+              1
+            ]
+          },
+          {
+            "id": 1043,
+            "type": "VAEDecode",
+            "pos": [
+              1467.5817848648687,
+              -361.87007866819795
+            ],
+            "size": [
+              140,
+              48.621998838299646
+            ],
+            "flags": {
+              "collapsed": false
+            },
+            "order": 4,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "samples",
+                "name": "samples",
+                "type": "LATENT",
+                "link": 1344
+              },
+              {
+                "localized_name": "vae",
+                "name": "vae",
+                "type": "VAE",
+                "link": 1077
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "IMAGE",
+                "name": "IMAGE",
+                "type": "IMAGE",
+                "slot_index": 0,
+                "links": [
+                  1078
+                ]
+              }
+            ],
+            "title": "Decode Pass 2",
+            "properties": {
+              "cnr_id": "comfy-core",
+              "ver": "0.3.45",
+              "Node name for S&R": "VAEDecode",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.8",
+                "input_ue_unconnectable": {}
+              }
+            },
+            "widgets_values": []
+          },
+          {
+            "id": 1039,
+            "type": "SamplerCustom",
+            "pos": [
+              800.900686407553,
+              -414.6088522909141
+            ],
+            "size": [
+              271.125,
+              230
+            ],
+            "flags": {},
+            "order": 0,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "model",
+                "name": "model",
+                "type": "MODEL",
+                "link": 1338
+              },
+              {
+                "localized_name": "positive",
+                "name": "positive",
+                "type": "CONDITIONING",
+                "link": 1325
+              },
+              {
+                "localized_name": "negative",
+                "name": "negative",
+                "type": "CONDITIONING",
+                "link": 1326
+              },
+              {
+                "localized_name": "sampler",
+                "name": "sampler",
+                "type": "SAMPLER",
+                "link": 1358
+              },
+              {
+                "localized_name": "sigmas",
+                "name": "sigmas",
+                "type": "SIGMAS",
+                "link": 1341
+              },
+              {
+                "localized_name": "latent_image",
+                "name": "latent_image",
+                "type": "LATENT",
+                "link": 1373
+              },
+              {
+                "localized_name": "noise_seed",
+                "name": "noise_seed",
+                "type": "INT",
+                "widget": {
+                  "name": "noise_seed"
+                },
+                "link": 1345
+              },
+              {
+                "localized_name": "cfg",
+                "name": "cfg",
+                "type": "FLOAT",
+                "widget": {
+                  "name": "cfg"
+                },
+                "link": 1497
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "output",
+                "name": "output",
+                "type": "LATENT",
+                "links": [
+                  1331
+                ]
+              },
+              {
+                "localized_name": "denoised_output",
+                "name": "denoised_output",
+                "type": "LATENT",
+                "links": []
+              }
+            ],
+            "properties": {
+              "cnr_id": "comfy-core",
+              "ver": "0.24.0",
+              "Node name for S&R": "SamplerCustom",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "input_ue_unconnectable": {},
+                "version": "7.8"
+              }
+            },
+            "widgets_values": [
+              true,
+              691997652254367,
+              "randomize",
+              0
+            ]
+          },
+          {
+            "id": 1042,
+            "type": "SamplerCustom",
+            "pos": [
+              1113.3513818908227,
+              -409.15720446498244
+            ],
+            "size": [
+              271.125,
+              230
+            ],
+            "flags": {},
+            "order": 3,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "model",
+                "name": "model",
+                "type": "MODEL",
+                "link": 1339
+              },
+              {
+                "localized_name": "positive",
+                "name": "positive",
+                "type": "CONDITIONING",
+                "link": 1329
+              },
+              {
+                "localized_name": "negative",
+                "name": "negative",
+                "type": "CONDITIONING",
+                "link": 1330
+              },
+              {
+                "localized_name": "sampler",
+                "name": "sampler",
+                "type": "SAMPLER",
+                "link": 1496
+              },
+              {
+                "localized_name": "sigmas",
+                "name": "sigmas",
+                "type": "SIGMAS",
+                "link": 1342
+              },
+              {
+                "localized_name": "latent_image",
+                "name": "latent_image",
+                "type": "LATENT",
+                "link": 1331
+              },
+              {
+                "localized_name": "noise_seed",
+                "name": "noise_seed",
+                "type": "INT",
+                "widget": {
+                  "name": "noise_seed"
+                },
+                "link": 1346
+              },
+              {
+                "localized_name": "cfg",
+                "name": "cfg",
+                "type": "FLOAT",
+                "widget": {
+                  "name": "cfg"
+                },
+                "link": 1498
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "output",
+                "name": "output",
+                "type": "LATENT",
+                "links": null
+              },
+              {
+                "localized_name": "denoised_output",
+                "name": "denoised_output",
+                "type": "LATENT",
+                "links": [
+                  1344
+                ]
+              }
+            ],
+            "properties": {
+              "cnr_id": "comfy-core",
+              "ver": "0.24.0",
+              "Node name for S&R": "SamplerCustom",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "input_ue_unconnectable": {},
+                "version": "7.8"
+              }
+            },
+            "widgets_values": [
+              false,
+              717771458822312,
+              "randomize",
+              1
+            ]
+          }
+        ],
+        "groups": [],
+        "links": [
+          {
+            "id": 1077,
+            "origin_id": -10,
+            "origin_slot": 1,
+            "target_id": 1043,
+            "target_slot": 1,
+            "type": "VAE"
+          },
+          {
+            "id": 1078,
+            "origin_id": 1043,
+            "origin_slot": 0,
+            "target_id": -20,
+            "target_slot": 0,
+            "type": "IMAGE"
+          },
+          {
+            "id": 1254,
+            "origin_id": -10,
+            "origin_slot": 7,
+            "target_id": 1040,
+            "target_slot": 0,
+            "type": "INT"
+          },
+          {
+            "id": 1325,
+            "origin_id": 1041,
+            "origin_slot": 0,
+            "target_id": 1039,
+            "target_slot": 1,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 1326,
+            "origin_id": 1041,
+            "origin_slot": 1,
+            "target_id": 1039,
+            "target_slot": 2,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 1329,
+            "origin_id": 1041,
+            "origin_slot": 0,
+            "target_id": 1042,
+            "target_slot": 1,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 1330,
+            "origin_id": 1041,
+            "origin_slot": 1,
+            "target_id": 1042,
+            "target_slot": 2,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 1331,
+            "origin_id": 1039,
+            "origin_slot": 0,
+            "target_id": 1042,
+            "target_slot": 5,
+            "type": "LATENT"
+          },
+          {
+            "id": 1333,
+            "origin_id": -10,
+            "origin_slot": 6,
+            "target_id": 1041,
+            "target_slot": 3,
+            "type": "LATENT"
+          },
+          {
+            "id": 1334,
+            "origin_id": -10,
+            "origin_slot": 5,
+            "target_id": 1041,
+            "target_slot": 2,
+            "type": "LATENT"
+          },
+          {
+            "id": 1335,
+            "origin_id": -10,
+            "origin_slot": 4,
+            "target_id": 1041,
+            "target_slot": 1,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 1336,
+            "origin_id": -10,
+            "origin_slot": 3,
+            "target_id": 1041,
+            "target_slot": 0,
+            "type": "CONDITIONING"
+          },
+          {
+            "id": 1338,
+            "origin_id": -10,
+            "origin_slot": 0,
+            "target_id": 1039,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 1339,
+            "origin_id": -10,
+            "origin_slot": 2,
+            "target_id": 1042,
+            "target_slot": 0,
+            "type": "MODEL"
+          },
+          {
+            "id": 1341,
+            "origin_id": -10,
+            "origin_slot": 9,
+            "target_id": 1039,
+            "target_slot": 4,
+            "type": "SIGMAS"
+          },
+          {
+            "id": 1342,
+            "origin_id": -10,
+            "origin_slot": 10,
+            "target_id": 1042,
+            "target_slot": 4,
+            "type": "SIGMAS"
+          },
+          {
+            "id": 1344,
+            "origin_id": 1042,
+            "origin_slot": 1,
+            "target_id": 1043,
+            "target_slot": 0,
+            "type": "LATENT"
+          },
+          {
+            "id": 1345,
+            "origin_id": 1040,
+            "origin_slot": 0,
+            "target_id": 1039,
+            "target_slot": 6,
+            "type": "INT"
+          },
+          {
+            "id": 1346,
+            "origin_id": 1040,
+            "origin_slot": 0,
+            "target_id": 1042,
+            "target_slot": 6,
+            "type": "INT"
+          },
+          {
+            "id": 1348,
+            "origin_id": -10,
+            "origin_slot": 11,
+            "target_id": 1041,
+            "target_slot": 4,
+            "type": "INT"
+          },
+          {
+            "id": 1358,
+            "origin_id": -10,
+            "origin_slot": 8,
+            "target_id": 1039,
+            "target_slot": 3,
+            "type": "SAMPLER"
+          },
+          {
+            "id": 1373,
+            "origin_id": 1041,
+            "origin_slot": 2,
+            "target_id": 1039,
+            "target_slot": 5,
+            "type": "LATENT"
+          },
+          {
+            "id": 1496,
+            "origin_id": -10,
+            "origin_slot": 12,
+            "target_id": 1042,
+            "target_slot": 3,
+            "type": "SAMPLER"
+          },
+          {
+            "id": 1497,
+            "origin_id": -10,
+            "origin_slot": 13,
+            "target_id": 1039,
+            "target_slot": 7,
+            "type": "FLOAT"
+          },
+          {
+            "id": 1498,
+            "origin_id": -10,
+            "origin_slot": 14,
+            "target_id": 1042,
+            "target_slot": 7,
+            "type": "FLOAT"
+          }
+        ],
+        "extra": {
+          "ue_links": [],
+          "links_added_by_ue": []
+        }
+      },
+      {
+        "id": "083335c7-23f1-4ebb-8fa5-df3fb44aa39f",
+        "version": 1,
+        "state": {
+          "lastGroupId": 12,
+          "lastNodeId": 1151,
+          "lastLinkId": 1529,
+          "lastRerouteId": 0
+        },
+        "revision": 0,
+        "config": {},
+        "name": "CalculateWidthHeight",
+        "inputNode": {
+          "id": -10,
+          "bounding": [
+            -734.9723892365105,
+            -1503.1955690086243,
+            128,
+            108
+          ]
+        },
+        "outputNode": {
+          "id": -20,
+          "bounding": [
+            13.083938888491389,
+            -1493.1955690086243,
+            128,
+            88
+          ]
+        },
+        "inputs": [
+          {
+            "id": "fb7f9d4e-f63e-4157-846c-9f685f82a17b",
+            "name": "image",
+            "type": "IMAGE",
+            "linkIds": [
+              1450
+            ],
+            "localized_name": "image",
+            "shape": 7,
+            "pos": [
+              -630.9723892365105,
+              -1479.1955690086243
+            ]
+          },
+          {
+            "id": "2a52ce64-7d8e-4e15-bbc6-8d29af16ccf7",
+            "name": "IF_TRUE",
+            "type": "*",
+            "linkIds": [
+              1455,
+              1454
+            ],
+            "localized_name": "IF_TRUE",
+            "pos": [
+              -630.9723892365105,
+              -1459.1955690086243
+            ]
+          },
+          {
+            "id": "c1adf30a-ad24-4355-b0d5-451b2ad0b0d9",
+            "name": "IF_FALSE",
+            "type": "*",
+            "linkIds": [
+              1453,
+              1456
+            ],
+            "localized_name": "IF_FALSE",
+            "pos": [
+              -630.9723892365105,
+              -1439.1955690086243
+            ]
+          }
+        ],
+        "outputs": [
+          {
+            "id": "1ed7de63-1804-4ffc-987a-727afce49f2f",
+            "name": "?",
+            "type": "*",
+            "linkIds": [
+              1451
+            ],
+            "localized_name": "?",
+            "label": "Width",
+            "pos": [
+              37.08393888849139,
+              -1469.1955690086243
+            ]
+          },
+          {
+            "id": "5e0a34bb-a004-4a1c-bc31-32bd914e7c03",
+            "name": "?_1",
+            "type": "*",
+            "linkIds": [
+              1452
+            ],
+            "localized_name": "?_1",
+            "label": "Height",
+            "pos": [
+              37.08393888849139,
+              -1449.1955690086243
+            ]
+          }
+        ],
+        "widgets": [],
+        "nodes": [
+          {
+            "id": 1104,
+            "type": "Image Aspect Ratio",
+            "pos": [
+              -546.9723892365105,
+              -1474.1198854148734
+            ],
+            "size": [
+              204.568359375,
+              106
+            ],
+            "flags": {},
+            "order": 0,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "image",
+                "name": "image",
+                "shape": 7,
+                "type": "IMAGE",
+                "link": 1450
+              },
+              {
+                "localized_name": "width",
+                "name": "width",
+                "shape": 7,
+                "type": "NUMBER",
+                "link": null
+              },
+              {
+                "localized_name": "height",
+                "name": "height",
+                "shape": 7,
+                "type": "NUMBER",
+                "link": null
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "aspect_number",
+                "name": "aspect_number",
+                "type": "NUMBER",
+                "links": null
+              },
+              {
+                "localized_name": "aspect_float",
+                "name": "aspect_float",
+                "type": "FLOAT",
+                "links": null
+              },
+              {
+                "localized_name": "is_landscape_bool",
+                "name": "is_landscape_bool",
+                "type": "NUMBER",
+                "links": [
+                  1448,
+                  1449
+                ]
+              },
+              {
+                "localized_name": "aspect_ratio_common",
+                "name": "aspect_ratio_common",
+                "type": "STRING",
+                "links": null
+              },
+              {
+                "localized_name": "aspect_type",
+                "name": "aspect_type",
+                "type": "STRING",
+                "links": null
+              }
+            ],
+            "properties": {
+              "cnr_id": "was-node-suite-comfyui",
+              "ver": "ea935d1044ae5a26efa54ebeb18fe9020af49a45",
+              "Node name for S&R": "Image Aspect Ratio",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "input_ue_unconnectable": {},
+                "version": "7.8"
+              }
+            },
+            "widgets_values": []
+          },
+          {
+            "id": 1106,
+            "type": "If ANY return A else B-🔬",
+            "pos": [
+              -230.8971157990086,
+              -1524.1760963523743
+            ],
+            "size": [
+              183.9810546875,
+              66
+            ],
+            "flags": {},
+            "order": 2,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "ANY",
+                "name": "ANY",
+                "type": "*",
+                "link": 1449
+              },
+              {
+                "localized_name": "IF_TRUE",
+                "name": "IF_TRUE",
+                "type": "*",
+                "link": 1456
+              },
+              {
+                "localized_name": "IF_FALSE",
+                "name": "IF_FALSE",
+                "type": "*",
+                "link": 1454
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "?",
+                "name": "?",
+                "type": "*",
+                "links": [
+                  1452
+                ]
+              }
+            ],
+            "title": "Height",
+            "properties": {
+              "cnr_id": "comfyui-logic",
+              "ver": "214cfba933291be224156d37bc30c25742076b44",
+              "Node name for S&R": "If ANY return A else B-🔬",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "input_ue_unconnectable": {},
+                "version": "7.8"
+              }
+            },
+            "widgets_values": []
+          },
+          {
+            "id": 1105,
+            "type": "If ANY return A else B-🔬",
+            "pos": [
+              -237.071935779568,
+              -1405.4592160768618
+            ],
+            "size": [
+              183.9810546875,
+              66
+            ],
+            "flags": {},
+            "order": 1,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "ANY",
+                "name": "ANY",
+                "type": "*",
+                "link": 1448
+              },
+              {
+                "localized_name": "IF_TRUE",
+                "name": "IF_TRUE",
+                "type": "*",
+                "link": 1455
+              },
+              {
+                "localized_name": "IF_FALSE",
+                "name": "IF_FALSE",
+                "type": "*",
+                "link": 1453
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "?",
+                "name": "?",
+                "type": "*",
+                "links": [
+                  1451
+                ]
+              }
+            ],
+            "title": "Width",
+            "properties": {
+              "cnr_id": "comfyui-logic",
+              "ver": "214cfba933291be224156d37bc30c25742076b44",
+              "Node name for S&R": "If ANY return A else B-🔬",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "input_ue_unconnectable": {},
+                "version": "7.8"
+              }
+            },
+            "widgets_values": []
+          }
+        ],
+        "groups": [],
+        "links": [
+          {
+            "id": 1448,
+            "origin_id": 1104,
+            "origin_slot": 2,
+            "target_id": 1105,
+            "target_slot": 0,
+            "type": "NUMBER"
+          },
+          {
+            "id": 1449,
+            "origin_id": 1104,
+            "origin_slot": 2,
+            "target_id": 1106,
+            "target_slot": 0,
+            "type": "NUMBER"
+          },
+          {
+            "id": 1450,
+            "origin_id": -10,
+            "origin_slot": 0,
+            "target_id": 1104,
+            "target_slot": 0,
+            "type": "IMAGE"
+          },
+          {
+            "id": 1455,
+            "origin_id": -10,
+            "origin_slot": 1,
+            "target_id": 1105,
+            "target_slot": 1,
+            "type": "INT"
+          },
+          {
+            "id": 1454,
+            "origin_id": -10,
+            "origin_slot": 1,
+            "target_id": 1106,
+            "target_slot": 2,
+            "type": "INT"
+          },
+          {
+            "id": 1453,
+            "origin_id": -10,
+            "origin_slot": 2,
+            "target_id": 1105,
+            "target_slot": 2,
+            "type": "INT"
+          },
+          {
+            "id": 1456,
+            "origin_id": -10,
+            "origin_slot": 2,
+            "target_id": 1106,
+            "target_slot": 1,
+            "type": "INT"
+          },
+          {
+            "id": 1451,
+            "origin_id": 1105,
+            "origin_slot": 0,
+            "target_id": -20,
+            "target_slot": 0,
+            "type": "INT"
+          },
+          {
+            "id": 1452,
+            "origin_id": 1106,
+            "origin_slot": 0,
+            "target_id": -20,
+            "target_slot": 1,
+            "type": "INT"
+          }
+        ],
+        "extra": {
+          "ue_links": [],
+          "links_added_by_ue": []
+        }
+      },
+      {
+        "id": "2a6f6651-87f0-4f47-94cc-ce5d2e872b6e",
+        "version": 1,
+        "state": {
+          "lastGroupId": 12,
+          "lastNodeId": 1151,
+          "lastLinkId": 1529,
+          "lastRerouteId": 0
+        },
+        "revision": 0,
+        "config": {},
+        "name": "Upscale & Interpolate",
+        "inputNode": {
+          "id": -10,
+          "bounding": [
+            1863.6515634614316,
+            680.2833142919584,
+            128,
+            68
+          ]
+        },
+        "outputNode": {
+          "id": -20,
+          "bounding": [
+            2865.7263206578195,
+            690.2833142919584,
+            128,
+            68
+          ]
+        },
+        "inputs": [
+          {
+            "id": "b011f480-a488-42e5-8ef6-e8cd1c202735",
+            "name": "image",
+            "type": "IMAGE",
+            "linkIds": [
+              1524
+            ],
+            "localized_name": "image",
+            "pos": [
+              1967.6515634614316,
+              704.2833142919584
+            ]
+          }
+        ],
+        "outputs": [
+          {
+            "id": "7609dfda-9828-4186-a408-c96d8c2ec5cd",
+            "name": "IMAGE",
+            "type": "IMAGE",
+            "linkIds": [
+              1526
+            ],
+            "pos": [
+              2889.7263206578195,
+              714.2833142919584
+            ]
+          }
+        ],
+        "widgets": [],
+        "nodes": [
+          {
+            "id": 1139,
+            "type": "ImageBlur",
+            "pos": [
+              2082.1841589867336,
+              203.85472780893144
+            ],
+            "size": [
+              270,
+              82
+            ],
+            "flags": {},
+            "order": 6,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "image",
+                "name": "image",
+                "type": "IMAGE",
+                "link": 1524
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "IMAGE",
+                "name": "IMAGE",
+                "type": "IMAGE",
+                "links": [
+                  1510
+                ]
+              }
+            ],
+            "properties": {
+              "cnr_id": "comfy-core",
+              "ver": "0.3.60",
+              "ue_properties": {
+                "widget_ue_connectable": {
+                  "blur_radius": true,
+                  "sigma": true
+                },
+                "version": "7.1",
+                "input_ue_unconnectable": {}
+              },
+              "Node name for S&R": "ImageBlur"
+            },
+            "widgets_values": [
+              1,
+              0.3
+            ]
+          },
+          {
+            "id": 1140,
+            "type": "LayerColor: BrightnessContrastV2",
+            "pos": [
+              2051.6515634614316,
+              337.4265275293804
+            ],
+            "size": [
+              320.1128845214844,
+              106
+            ],
+            "flags": {},
+            "order": 7,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "image",
+                "name": "image",
+                "type": "IMAGE",
+                "link": 1510
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "image",
+                "name": "image",
+                "type": "IMAGE",
+                "links": [
+                  1515,
+                  1529
+                ]
+              }
+            ],
+            "properties": {
+              "cnr_id": "comfyui_layerstyle",
+              "ver": "89014d833d2ad0998d724090eff1456692692a1d",
+              "ue_properties": {
+                "widget_ue_connectable": {
+                  "brightness": true,
+                  "contrast": true,
+                  "saturation": true
+                },
+                "version": "7.1",
+                "input_ue_unconnectable": {}
+              },
+              "Node name for S&R": "LayerColor: BrightnessContrastV2"
+            },
+            "widgets_values": [
+              1,
+              1.04,
+              1.04
+            ],
+            "color": "rgba(27, 89, 123, 0.7)"
+          },
+          {
+            "id": 1141,
+            "type": "GetImageSize",
+            "pos": [
+              2116.7552365981355,
+              563.2304079235131
+            ],
+            "size": [
+              140,
+              66
+            ],
+            "flags": {
+              "collapsed": true
+            },
+            "order": 3,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "image",
+                "name": "image",
+                "type": "IMAGE",
+                "link": 1511
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "width",
+                "name": "width",
+                "type": "INT",
+                "links": [
+                  1512
+                ]
+              },
+              {
+                "localized_name": "height",
+                "name": "height",
+                "type": "INT",
+                "links": [
+                  1513
+                ]
+              },
+              {
+                "localized_name": "batch_size",
+                "name": "batch_size",
+                "type": "INT",
+                "links": null
+              }
+            ],
+            "properties": {
+              "cnr_id": "comfy-core",
+              "ver": "0.24.0",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "input_ue_unconnectable": {},
+                "version": "7.8"
+              },
+              "Node name for S&R": "GetImageSize"
+            },
+            "widgets_values": []
+          },
+          {
+            "id": 1143,
+            "type": "ComfyMathExpression",
+            "pos": [
+              2111.28047230018,
+              647.5330856830908
+            ],
+            "size": [
+              400,
+              200
+            ],
+            "flags": {
+              "collapsed": true
+            },
+            "order": 5,
+            "mode": 0,
+            "inputs": [
+              {
+                "label": "a",
+                "localized_name": "values.a",
+                "name": "values.a",
+                "type": "FLOAT,INT,BOOLEAN",
+                "link": 1513
+              },
+              {
+                "label": "b",
+                "localized_name": "values.b",
+                "name": "values.b",
+                "shape": 7,
+                "type": "FLOAT,INT,BOOLEAN",
+                "link": null
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "FLOAT",
+                "name": "FLOAT",
+                "type": "FLOAT",
+                "links": null
+              },
+              {
+                "localized_name": "INT",
+                "name": "INT",
+                "type": "INT",
+                "links": [
+                  1518
+                ]
+              },
+              {
+                "localized_name": "BOOL",
+                "name": "BOOL",
+                "type": "BOOLEAN",
+                "links": null
+              }
+            ],
+            "properties": {
+              "cnr_id": "comfy-core",
+              "ver": "0.24.0",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "input_ue_unconnectable": {},
+                "version": "7.8"
+              },
+              "Node name for S&R": "ComfyMathExpression"
+            },
+            "widgets_values": [
+              "a * 2"
+            ]
+          },
+          {
+            "id": 1144,
+            "type": "ImageUpscaleWithModel",
+            "pos": [
+              2108.933710436214,
+              1085.5077481432786
+            ],
+            "size": [
+              233.5689453125,
+              46
+            ],
+            "flags": {},
+            "order": 8,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "upscale_model",
+                "name": "upscale_model",
+                "type": "UPSCALE_MODEL",
+                "link": 1514
+              },
+              {
+                "localized_name": "image",
+                "name": "image",
+                "type": "IMAGE",
+                "link": 1515
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "IMAGE",
+                "name": "IMAGE",
+                "type": "IMAGE",
+                "links": [
+                  1516
+                ]
+              }
+            ],
+            "properties": {
+              "cnr_id": "comfy-core",
+              "ver": "0.3.60",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.1",
+                "input_ue_unconnectable": {}
+              },
+              "Node name for S&R": "ImageUpscaleWithModel"
+            },
+            "widgets_values": []
+          },
+          {
+            "id": 1147,
+            "type": "ImageUpscaleWithModel",
+            "pos": [
+              2517.5444164379883,
+              1092.329414849315
+            ],
+            "size": [
+              233.5689453125,
+              46
+            ],
+            "flags": {},
+            "order": 10,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "upscale_model",
+                "name": "upscale_model",
+                "type": "UPSCALE_MODEL",
+                "link": 1519
+              },
+              {
+                "localized_name": "image",
+                "name": "image",
+                "type": "IMAGE",
+                "link": 1520
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "IMAGE",
+                "name": "IMAGE",
+                "type": "IMAGE",
+                "links": [
+                  1521
+                ]
+              }
+            ],
+            "properties": {
+              "cnr_id": "comfy-core",
+              "ver": "0.3.60",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.1",
+                "input_ue_unconnectable": {}
+              },
+              "Node name for S&R": "ImageUpscaleWithModel"
+            },
+            "widgets_values": []
+          },
+          {
+            "id": 1150,
+            "type": "UpscaleModelLoader",
+            "pos": [
+              2074.3344716243155,
+              1193.859996015141
+            ],
+            "size": [
+              270,
+              58
+            ],
+            "flags": {},
+            "order": 1,
+            "mode": 0,
+            "inputs": [],
+            "outputs": [
+              {
+                "localized_name": "UPSCALE_MODEL",
+                "name": "UPSCALE_MODEL",
+                "type": "UPSCALE_MODEL",
+                "links": [
+                  1514
+                ]
+              }
+            ],
+            "properties": {
+              "cnr_id": "comfy-core",
+              "ver": "0.3.60",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.1",
+                "input_ue_unconnectable": {}
+              },
+              "Node name for S&R": "UpscaleModelLoader"
+            },
+            "widgets_values": [
+              "4x-ClearRealityV1_Soft.pth"
+            ]
+          },
+          {
+            "id": 1146,
+            "type": "ImageResizeKJv2",
+            "pos": [
+              2079.383541762977,
+              696.8533098536291
+            ],
+            "size": [
+              269.73371937731554,
+              336
+            ],
+            "flags": {
+              "collapsed": false
+            },
+            "order": 9,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "image",
+                "name": "image",
+                "type": "IMAGE",
+                "link": 1516
+              },
+              {
+                "localized_name": "mask",
+                "name": "mask",
+                "shape": 7,
+                "type": "MASK",
+                "link": null
+              },
+              {
+                "localized_name": "width",
+                "name": "width",
+                "type": "INT",
+                "widget": {
+                  "name": "width"
+                },
+                "link": 1517
+              },
+              {
+                "localized_name": "height",
+                "name": "height",
+                "type": "INT",
+                "widget": {
+                  "name": "height"
+                },
+                "link": 1518
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "IMAGE",
+                "name": "IMAGE",
+                "type": "IMAGE",
+                "links": [
+                  1520
+                ]
+              },
+              {
+                "localized_name": "width",
+                "name": "width",
+                "type": "INT",
+                "links": null
+              },
+              {
+                "localized_name": "height",
+                "name": "height",
+                "type": "INT",
+                "links": null
+              },
+              {
+                "localized_name": "mask",
+                "name": "mask",
+                "type": "MASK",
+                "links": null
+              }
+            ],
+            "properties": {
+              "cnr_id": "comfyui-kjnodes",
+              "ver": "204f6d5aae73b10c0fe2fb26e61405fd6337bb77",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "input_ue_unconnectable": {},
+                "version": "7.8"
+              },
+              "Node name for S&R": "ImageResizeKJv2"
+            },
+            "widgets_values": [
+              512,
+              512,
+              "lanczos",
+              "resize",
+              "0, 0, 0",
+              "center",
+              2,
+              "cpu"
+            ]
+          },
+          {
+            "id": 1148,
+            "type": "UpscaleModelLoader",
+            "pos": [
+              2505.3889311944818,
+              1196.7119007749852
+            ],
+            "size": [
+              270,
+              58
+            ],
+            "flags": {},
+            "order": 2,
+            "mode": 0,
+            "inputs": [],
+            "outputs": [
+              {
+                "localized_name": "UPSCALE_MODEL",
+                "name": "UPSCALE_MODEL",
+                "type": "UPSCALE_MODEL",
+                "links": [
+                  1519
+                ]
+              }
+            ],
+            "properties": {
+              "cnr_id": "comfy-core",
+              "ver": "0.3.60",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.1",
+                "input_ue_unconnectable": {}
+              },
+              "Node name for S&R": "UpscaleModelLoader"
+            },
+            "widgets_values": [
+              "x1_ITF_SkinDiffDDS_v1.pth"
+            ]
+          },
+          {
+            "id": 1149,
+            "type": "RIFE VFI",
+            "pos": [
+              2478.6262535191477,
+              684.402147476196
+            ],
+            "size": [
+              327.1000671386719,
+              270
+            ],
+            "flags": {},
+            "order": 11,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "frames",
+                "name": "frames",
+                "type": "IMAGE",
+                "link": 1521
+              },
+              {
+                "localized_name": "optional_interpolation_states",
+                "name": "optional_interpolation_states",
+                "shape": 7,
+                "type": "INTERPOLATION_STATES",
+                "link": null
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "IMAGE",
+                "name": "IMAGE",
+                "type": "IMAGE",
+                "links": [
+                  1526
+                ]
+              }
+            ],
+            "properties": {
+              "cnr_id": "comfyui-frame-interpolation",
+              "ver": "a969c01dbccd9e5510641be04eb51fe93f6bfc3d",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "version": "7.1",
+                "input_ue_unconnectable": {}
+              },
+              "Node name for S&R": "RIFE VFI"
+            },
+            "widgets_values": [
+              "rife49.pth",
+              3,
+              4,
+              false,
+              true,
+              1,
+              "float16",
+              true,
+              1
+            ]
+          },
+          {
+            "id": 1145,
+            "type": "ImageFromBatch",
+            "pos": [
+              2109.3116912879195,
+              516.6270976087251
+            ],
+            "size": [
+              268.40231626389095,
+              82.26884101328756
+            ],
+            "flags": {
+              "collapsed": true
+            },
+            "order": 0,
+            "mode": 0,
+            "inputs": [
+              {
+                "localized_name": "image",
+                "name": "image",
+                "type": "IMAGE",
+                "link": 1529
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "IMAGE",
+                "name": "IMAGE",
+                "type": "IMAGE",
+                "links": [
+                  1511
+                ]
+              }
+            ],
+            "properties": {
+              "cnr_id": "comfy-core",
+              "ver": "0.24.0",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "input_ue_unconnectable": {},
+                "version": "7.8"
+              },
+              "Node name for S&R": "ImageFromBatch"
+            },
+            "widgets_values": [
+              0,
+              1
+            ]
+          },
+          {
+            "id": 1142,
+            "type": "ComfyMathExpression",
+            "pos": [
+              2110.745141815951,
+              608.2327646273534
+            ],
+            "size": [
+              400,
+              200
+            ],
+            "flags": {
+              "collapsed": true
+            },
+            "order": 4,
+            "mode": 0,
+            "inputs": [
+              {
+                "label": "a",
+                "localized_name": "values.a",
+                "name": "values.a",
+                "type": "FLOAT,INT,BOOLEAN",
+                "link": 1512
+              },
+              {
+                "label": "b",
+                "localized_name": "values.b",
+                "name": "values.b",
+                "shape": 7,
+                "type": "FLOAT,INT,BOOLEAN",
+                "link": null
+              }
+            ],
+            "outputs": [
+              {
+                "localized_name": "FLOAT",
+                "name": "FLOAT",
+                "type": "FLOAT",
+                "links": null
+              },
+              {
+                "localized_name": "INT",
+                "name": "INT",
+                "type": "INT",
+                "links": [
+                  1517
+                ]
+              },
+              {
+                "localized_name": "BOOL",
+                "name": "BOOL",
+                "type": "BOOLEAN",
+                "links": null
+              }
+            ],
+            "properties": {
+              "cnr_id": "comfy-core",
+              "ver": "0.24.0",
+              "ue_properties": {
+                "widget_ue_connectable": {},
+                "input_ue_unconnectable": {},
+                "version": "7.8"
+              },
+              "Node name for S&R": "ComfyMathExpression"
+            },
+            "widgets_values": [
+              "a * 2"
+            ]
+          }
+        ],
+        "groups": [],
+        "links": [
+          {
+            "id": 1510,
+            "origin_id": 1139,
+            "origin_slot": 0,
+            "target_id": 1140,
+            "target_slot": 0,
+            "type": "IMAGE"
+          },
+          {
+            "id": 1511,
+            "origin_id": 1145,
+            "origin_slot": 0,
+            "target_id": 1141,
+            "target_slot": 0,
+            "type": "IMAGE"
+          },
+          {
+            "id": 1512,
+            "origin_id": 1141,
+            "origin_slot": 0,
+            "target_id": 1142,
+            "target_slot": 0,
+            "type": "INT"
+          },
+          {
+            "id": 1513,
+            "origin_id": 1141,
+            "origin_slot": 1,
+            "target_id": 1143,
+            "target_slot": 0,
+            "type": "INT"
+          },
+          {
+            "id": 1514,
+            "origin_id": 1150,
+            "origin_slot": 0,
+            "target_id": 1144,
+            "target_slot": 0,
+            "type": "UPSCALE_MODEL"
+          },
+          {
+            "id": 1515,
+            "origin_id": 1140,
+            "origin_slot": 0,
+            "target_id": 1144,
+            "target_slot": 1,
+            "type": "IMAGE"
+          },
+          {
+            "id": 1519,
+            "origin_id": 1148,
+            "origin_slot": 0,
+            "target_id": 1147,
+            "target_slot": 0,
+            "type": "UPSCALE_MODEL"
+          },
+          {
+            "id": 1520,
+            "origin_id": 1146,
+            "origin_slot": 0,
+            "target_id": 1147,
+            "target_slot": 1,
+            "type": "IMAGE"
+          },
+          {
+            "id": 1521,
+            "origin_id": 1147,
+            "origin_slot": 0,
+            "target_id": 1149,
+            "target_slot": 0,
+            "type": "IMAGE"
+          },
+          {
+            "id": 1516,
+            "origin_id": 1144,
+            "origin_slot": 0,
+            "target_id": 1146,
+            "target_slot": 0,
+            "type": "IMAGE"
+          },
+          {
+            "id": 1517,
+            "origin_id": 1142,
+            "origin_slot": 1,
+            "target_id": 1146,
+            "target_slot": 2,
+            "type": "INT"
+          },
+          {
+            "id": 1518,
+            "origin_id": 1143,
+            "origin_slot": 1,
+            "target_id": 1146,
+            "target_slot": 3,
+            "type": "INT"
+          },
+          {
+            "id": 1524,
+            "origin_id": -10,
+            "origin_slot": 0,
+            "target_id": 1139,
+            "target_slot": 0,
+            "type": "IMAGE"
+          },
+          {
+            "id": 1526,
+            "origin_id": 1149,
+            "origin_slot": 0,
+            "target_id": -20,
+            "target_slot": 0,
+            "type": "IMAGE"
+          },
+          {
+            "id": 1529,
+            "origin_id": 1140,
+            "origin_slot": 0,
+            "target_id": 1145,
+            "target_slot": 0,
+            "type": "IMAGE"
+          }
+        ],
+        "extra": {
+          "ue_links": [],
+          "links_added_by_ue": []
+        }
+      }
+    ]
+  },
+  "config": {},
+  "extra": {
+    "frontendVersion": "1.45.15",
+    "groupNodes": {},
+    "workspace_info": {
+      "id": "hSBfPb8KVVUoyCyWT3oHM"
+    },
+    "node_versions": {
+      "ComfyUI-Frame-Interpolation": "c336f7184cb1ac1243381e725fea1ad2c0a10c09",
+      "ComfyUI-VideoHelperSuite": "8629188458dc6cb832f871ece3bd273507e8a766",
+      "comfy-core": "0.3.15",
+      "ComfyUI_essentials": "33ff89fd354d8ec3ab6affb605a79a931b445d99",
+      "was-node-suite-comfyui": "2afeeeb7d17198cb5a84ed33c4634fe5d171d152",
+      "ComfyLiterals": "bdddb08ca82d90d75d97b1d437a652e0284a32ac",
+      "ComfyUI-Easy-Use": "123917da9adec0d2b0b5f817deefb9ac3ed464f1",
+      "ComfyUI-Impact-Pack": "1ae7cae2df8cca06027edfa3a24512671239d6c4",
+      "ComfyUI-WanVideoWrapper": "44c5944f7031949440315038e94ca3f46e80adb2",
+      "cg-use-everywhere": "ce510b97d10e69d5fd0042e115ecd946890d2079"
+    },
+    "ue_links": [],
+    "VHS_latentpreview": true,
+    "VHS_latentpreviewrate": 0,
+    "VHS_MetadataImage": true,
+    "VHS_KeepIntermediate": true,
+    "links_added_by_ue": [],
+    "ds": {
+      "scale": 0.6830134553650705,
+      "offset": [
+        1577.9451836426565,
+        1415.3152875177843
+      ]
+    }
+  },
+  "version": 0.4
+}


### PR DESCRIPTION
Both SVI 4-pass flows have only ever existed as Discord attachments, so anyone who deployed the template looking for them came up empty. This adds them.

**Added**

- `workflows/Wan 2.2/Video Generation/SVI 4-pass/HearmemanAI_Wan2.2_SVI_4pass.json` — the original "Wan 2.2 SVI 4-pass + MoreMotion" (GGUF SVI-Camera unet pair)
- `workflows/Wan 2.2/Video Generation/SVI 4-pass/Wan2.2_SVI_4pass_V3.json` — "Wan 2.2 SVI 4-pass V3" (per-segment LoRA selection, Lightning high+low pair)

Both files are byte-for-byte the Discord attachments. They sit under `Wan 2.2/` rather than a new top-level folder so `download_wan22` picks them up with no change to `FLAG_DIRS` in the provisioner.

**Registry**

Three new entries, all HF, all verified reachable:

| model | subdir | used by |
|---|---|---|
| `lightx2v_I2V_14B_480p_cfg_step_distill_rank128_bf16.safetensors` | `loras` | V1 |
| `4x-ClearRealityV1_Soft.pth` | `upscale_models` | V3 |
| `x1_ITF_SkinDiffDDS_v1.pth` | `upscale_models` | V3 |

URLs are the ones from the thread posts, not guessed.

**What's still not covered**

Adding the JSONs does not by itself make these two flows run out of the box. What a user still has to supply:

*V1 — hard blockers*
- `wan22EnhancedNSFWSVICamera_nolightningSVICfQ8H.gguf` (CivitAI 2668710, 14.4 GB)
- `wan22EnhancedNSFWSVICamera_nolightningSVICfQ8L.gguf` (CivitAI 2668712, 14.4 GB)

These are the workflow's two unets — without them nothing runs. They're CivitAI-only and the registry has no token support, so they stay a `CHECKPOINT_IDS_TO_DOWNLOAD` passthrough. Worse, the provisioner's `MODEL_PAT` doesn't match `.gguf` at all, so the user doesn't even get the "user-supplied" warning on boot. Happy to extend the pattern in a follow-up if you want that visible.

*V3 — hard blocker*
- `DR34ML4Y_I2V_14B_HIGH_V2.safetensors` / `DR34ML4Y_I2V_14B_LOW_V2.safetensors` — enabled by default in all four segment LoRA loaders. CivitAI, not in the thread's model list, so I didn't guess a URL.

*V3 — optional*
- `smash_cut_wan_high_250.safetensors` — present but toggled off, so it won't block a run.

*Already handled elsewhere*
- `2xLiveActionV1_SPAN_490000.pth` (V1) — `start.sh` already downloads this unconditionally. It's the first workflow to reference it, so the validator now prints it as a user-supplied warning even though it ships. Warning only, CI stays green.
- `rife49.pth` — auto-download allowlist.
- All custom nodes the two flows need are already provisioned: KJNodes (pin `204f6d5` postdates the `WanImageToVideoSVIPro` commit, so the node is there), rgthree, GGUF, Frame-Interpolation, LayerStyle, WAS, ComfyUI-Logic, ComfyLiterals, and WanMoEScheduler via the runtime clone list.

So: **"preinstalled" is now true for the workflows and their HF models, and still false for the CivitAI NSFW weights both flows lean on.**

**Two things worth a second look**

1. The V1 thread is locked and points at V3 as its replacement. Shipping V1 anyway is a judgement call — say the word and I'll drop it.
2. V3 references `i2v_lightx2v_high_noise_model.safetensors` / `..._low_noise_model.safetensors`, which the registry already resolves to `lightx2v/Wan2.2-Distill-Loras/…rank64_lightx2v_4step_1022`. The thread post names the Seko-V1 Lightning pair instead. Same filenames, different weights. I left the existing entries alone since other workflows depend on them, but if the thread is right, the registry URLs are pointing at the wrong file.

**Verified**

- `tools/validate_models.py` — 35 entries, all URLs reachable, no errors
- `workflow_provisioner.py --flag download_wan22` dry run — both JSONs copied, all three new models queued to the right subdirs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
