### PR TITLE
start_script: name global networking as the cause of a DNS-dead pod

### DIFF
--- a/src/start_script.sh
+++ b/src/start_script.sh
@@ -13,6 +13,44 @@
 REPO_DIR=/comfyui-wan
 REPO_URL=https://github.com/Hearmeman24/comfyui-wan.git
 
+# Preflight. RunPod's "global networking" blocks outbound DNS, so the first
+# thing that touches the network dies with "Could not resolve host:
+# github.com" and sends the user off to check GitHub instead of the pod
+# setting that actually broke it. Resolve two known hosts up front and, if
+# neither answers, say what it is and stop — before the retry loop turns one
+# clear cause into 75 seconds of git errors.
+TIMEOUT=""
+command -v timeout >/dev/null 2>&1 && TIMEOUT="timeout 5"
+check_host() {
+    # shellcheck disable=SC2086  # $TIMEOUT is a command prefix, not an argument
+    $TIMEOUT getent hosts "$1" >/dev/null 2>&1 && return 0
+    $TIMEOUT python3 -c 'import socket,sys; socket.gethostbyname(sys.argv[1])' "$1" >/dev/null 2>&1
+}
+
+if ! check_host github.com && ! check_host huggingface.co; then
+    cat >&2 <<'EOF'
+
+════════════════════════════════════════════════════════════════════════
+❌  No DNS. Nothing can be downloaded, so the pod is stopping here.
+
+    The cause is almost always GLOBAL NETWORKING being enabled on this
+    pod. It blocks outbound DNS, so github.com and huggingface.co stop
+    resolving and ComfyUI, the custom nodes and every model download
+    fail before they start.
+
+    Fix: disable global networking and redeploy.
+      RunPod console -> your pod -> Edit Pod -> uncheck "Global
+      Networking" -> Save. On a new pod the same checkbox is on the
+      deploy screen, under the network volume picker.
+
+    If global networking is already off, the pod has no outbound
+    network at all — try a different region or data center.
+════════════════════════════════════════════════════════════════════════
+
+EOF
+    exit 1
+fi
+
 sync_repo() {
     if [ -d "$REPO_DIR/.git" ]; then
         git -C "$REPO_DIR" fetch --depth=1 origin master &&


### PR DESCRIPTION
A pod with RunPod global networking enabled has no outbound DNS. The first thing `src/start_script.sh` does is sync the repo from GitHub, so the pod died 75 seconds later on

```
fatal: unable to access '...': Could not resolve host: github.com
```

which points the user at GitHub instead of at the pod setting that actually broke it. It was the largest single support cluster in the last 28 days of the Discord (~10 people, hand-diagnosed three times).

## What changed

`src/start_script.sh`, +38/-0. One function and one guard, between the `REPO_URL` assignment and `sync_repo()`. Resolve `github.com` and `huggingface.co`; when neither answers, print a block naming global networking and where the checkbox lives, then exit non-zero.

- **Aborts only when both hosts fail** — one host being down is still working DNS, and should stay a retry, not a bricked boot.
- **`getent` first, `python3` fallback** — `getent` is the cheap libc path in the image; the fallback keeps the check working if it's absent.
- **`timeout` used only if present** — a missing `timeout` would otherwise turn every boot into a false abort.

Download and provisioning logic is untouched: the retry loop, the stale-copy fallback, `hf_download_manager.py` and `workflow_provisioner.py` are all unchanged.

## What the user sees now

```
════════════════════════════════════════════════════════════════════════
❌  No DNS. Nothing can be downloaded, so the pod is stopping here.

    The cause is almost always GLOBAL NETWORKING being enabled on this
    pod. It blocks outbound DNS, so github.com and huggingface.co stop
    resolving and ComfyUI, the custom nodes and every model download
    fail before they start.

    Fix: disable global networking and redeploy.
      RunPod console -> your pod -> Edit Pod -> uncheck "Global
      Networking" -> Save. On a new pod the same checkbox is on the
      deploy screen, under the network volume picker.

    If global networking is already off, the pod has no outbound
    network at all — try a different region or data center.
════════════════════════════════════════════════════════════════════════
--- exit=1 elapsed=0s ---
```

75 seconds and the wrong culprit becomes 0 seconds and the right one.

## Verification

No shell test harness in the repo, so the checks ran from a throwaway that stubs `getent`/`python3`/`git` on `PATH` to simulate a pod with no DNS, then runs the real `src/start_script.sh`:

```
=== case 1: real network resolves github.com ===
PASS: check_host github.com succeeds on a working network

=== case 2: nothing resolves ===
PASS: check_host fails when no resolver works

=== case 3: full entrypoint on a pod with global networking on ===
PASS: entrypoint exits non-zero
PASS: message names global networking
PASS: message names the RunPod setting
PASS: fails before any git call (no misleading git error)
PASS: fails fast (<30s, no long retry loop)

=== case 4: working network is not blocked by the preflight ===
PASS: no false abort when DNS works
PASS: reaches the repo sync

ALL PASS
```

Case 4 is the regression guard: with real DNS the script sails through the preflight into the repo sync, so the diagnostic cannot brick a healthy pod. Against the pre-fix script, case 3's last four assertions all FAIL.

The repo's own CI gates (`.github/workflows/static-checks.yml`), run locally:

```
$ bash -n src/start.sh src/start_script.sh          # ok
$ shellcheck --severity=error src/start.sh src/start_script.sh   # clean
$ shellcheck src/start_script.sh                    # exit=0
```

**Not verified:** the message on a real pod with global networking actually on. The exact console wording ("Edit Pod", the deploy-screen checkbox) is written from the UI as described in the support thread, not read off a live console — worth a glance before this reaches customers, since the whole value of the change is that the instruction is followable.

Linear: [HEA-97](https://linear.app/hearmemanai/issue/HEA-97/wan-detect-global-networking-at-boot-instead-of-failing-on-a-git-dns)
