### PR TITLE
ci: run validate-models weekly on a schedule

### DIFF
--- a/.github/workflows/validate-models.yml
+++ b/.github/workflows/validate-models.yml
@@ -4,6 +4,11 @@ on:
     branches: [main, master]
   pull_request:
     branches: [main, master]
+  schedule:
+    # Weekly re-run against upstream rot: registry URLs can 404 without any
+    # push here, and push-only validation leaves CI green over a broken
+    # template. Mondays 06:00 UTC.
+    - cron: '0 6 * * 1'
 
 jobs:
   validate:


### PR DESCRIPTION
## What changed

Added a schedule trigger to .github/workflows/validate-models.yml. The existing push and pull_request triggers are untouched.

Cron: 0 6 * * 1 (Mondays 06:00 UTC).

## Why

The validator only fires on pushes and PRs to this repo. When upstream moves or deletes a model file, nothing here changes, so CI stays green over a broken template until the next edit, and a customer finds the breakage before CI does. A weekly run converts a gate that catches our mistakes into one that catches the world's.

## What a scheduled run executes

Exactly the existing validate job on master: checkout, Python 3.12, pip install httpx, python tools/validate_models.py. The job reads only the repo contents and remote URLs; it has no dependency on push event context, so a schedule-triggered run does the same work a push-triggered run does.

## What to watch on the first firing

- First scheduled run: Monday 2026-08-17 06:00 UTC (GitHub may delay scheduled runs by some minutes under load).
- GitHub disables scheduled workflows in repos with no pushes for 60 days; a push or manually re-enabling the workflow resets the clock. Worth knowing if this repo goes quiet.
- A red run here means a registry URL or workflow reference rotted upstream, not that this change broke.