### PR TITLE
Pin the runtime at a946ec91 for the handoff-stall fix

### DIFF
--- a/pins.json
+++ b/pins.json
@@ -1,4 +1,4 @@
 {
-  "runtime_ref": "e54e929fa539d08f607783526501843332132a41",
+  "runtime_ref": "a946ec91bdea00e6945524058abefc4227cd90aa",
   "base_image": "hearmeman/comfyui-base:cu130-comfy0.32.0-torch2.11.0"
 }


### PR DESCRIPTION
One commit in range, `comfyui-runtime#11`: the download watchdog no longer counts an active stage->volume copy as zero progress.

It killed three healthy 20 GB transfers on a minimax pod today, at the 5 minute stall timeout, while they were copying to the volume. wan is the most exposed template in the family at 320 GB: any file whose handoff exceeds `STALL_SECS` hits the same wall, and the volume caps near 150 MB/s regardless of how many writers.

Also in the fix: the handoff is now serialized (concurrent copies only split the same bandwidth), the snapshot labels the phase instead of showing a frozen 100% at 0.0 B/s, and the stale `.partial` sweep walks destination directories so a flag-disabled or renamed model's leftover can actually be reclaimed.

`pins.json` is git-pulled at boot, so no rebuild and no new tag. v26 pods pick this up on their next boot.

Validator online after the bump: 39 entries, 28 warnings, unchanged.

Not verified: no pod. The real handoff against a RunPod volume is unexercised.