### PR TITLE
Follow the runtime's stable branch instead of a pinned SHA

### DIFF
--- a/pins.json
+++ b/pins.json
@@ -1,4 +1,4 @@
 {
-  "runtime_ref": "a946ec91bdea00e6945524058abefc4227cd90aa",
+  "runtime_ref": "stable",
   "base_image": "hearmeman/comfyui-base:cu130-comfy0.32.0-torch2.11.0"
 }


### PR DESCRIPTION
One line, and it should be the last time this file changes.

`runtime_ref` becomes `stable` instead of a SHA. Promoting a runtime fix to all templates becomes moving `comfyui-runtime`'s `stable` branch once; rolling back is moving it back. No more per-template PRs.

**No rebuild.** `src/start_script.sh:75-76` already runs `git fetch origin \$RUNTIME_REF` then `reset --hard FETCH_HEAD`, which resolves a branch name exactly as it resolves a SHA. Verified against a bare clone across three boots:

```
boot 1, stable=a946ec9        -> HEAD a946ec9
boot 2, stable rolled back    -> HEAD e54e929
boot 3, stable rolled forward -> HEAD a946ec9
```

Full-SHA fetches still work against GitHub too, so a pod can still be pointed at an exact commit.

`stable` currently points at `a946ec91`, which is what this template already pinned, so **this changes no behaviour today**.

Still to come, needs a rebuild because `start_script.sh` is baked: a `RUNTIME_REF` env override so a single pod can be pointed elsewhere without touching git. It can ride whatever tag this template cuts next.