### PR TITLE
Ship the 2x live-action SPAN upscaler

### DIFF
--- a/src/models_registry.json
+++ b/src/models_registry.json
@@ -9,6 +9,11 @@
     "subdir": "upscale_models",
     "min_size_mb": 5
   },
+  "2xLiveActionV1_SPAN_490000.pth": {
+    "url": "https://huggingface.co/Hearmeman/comfyui-template-assets/resolve/main/upscale_models/2xLiveActionV1_SPAN_490000.pth",
+    "subdir": "upscale_models",
+    "min_size_mb": 5
+  },
   "4xLSDIR.pth": {
     "url": "https://huggingface.co/Hearmeman/comfyui-template-assets/resolve/main/upscale_models/4xLSDIR.pth",
     "subdir": "upscale_models"

--- a/template.json
+++ b/template.json
@@ -8,6 +8,7 @@
         "Wan 2.1"
       ],
       "extra_models": [
+        "2xLiveActionV1_SPAN_490000.pth",
         "rife426.pth"
       ]
     },
@@ -16,6 +17,7 @@
         "Wan 2.2"
       ],
       "extra_models": [
+        "2xLiveActionV1_SPAN_490000.pth",
         "rife426.pth"
       ]
     },
@@ -25,6 +27,7 @@
       ],
       "extra_models": [
         "1x-ITF-SkinDiffDetail-Lite-v1.pth",
+        "2xLiveActionV1_SPAN_490000.pth",
         "rife426.pth"
       ]
     },
@@ -33,6 +36,7 @@
         "Steady Dancer"
       ],
       "extra_models": [
+        "2xLiveActionV1_SPAN_490000.pth",
         "rife426.pth"
       ]
     },
@@ -41,6 +45,7 @@
         "SCAIL-2"
       ],
       "extra_models": [
+        "2xLiveActionV1_SPAN_490000.pth",
         "rife426.pth"
       ]
     }


### PR DESCRIPTION
Adds `2xLiveActionV1_SPAN_490000.pth` to the Wan template, from `Hearmeman/comfyui-template-assets`.

## Tier 2

Registry + `template.json` only. Lands on the next pod boot, no rebuild, no tag.

## Why it is on every flag

No workflow loads it, so it goes in `extra_models` rather than arriving via a graph. It sits on all five flags — the same shape as `rife426.pth` — because it is a general-purpose tool you want present whatever you enabled, and at 8.5 MiB it is not worth gating behind one.

## The `min_size_mb` is load-bearing

This is the part worth reading. The file is **8,947,821 bytes**, measured off the resolve URL. `MIN_OK_SIZE` is 10 MiB (`comfyui-runtime/src/provisioner.py:44`), so it never clears the "looks complete" bar:

- `provisioner.py:272` — never counts as already present, re-queues every boot
- `hf_download_manager.py:472` — raises on the *finished* download for being below the floor

So without a floor override it would never install at all, and would log an error into `comfyui.log` on every single boot. `min_size_mb: 5` is what `4x-ClearRealityV1_Soft.pth` already carries for exactly this reason. It rides along as the manifest's third field, so the downloader verifies against the same number the provisioner used.

## Verified

Drove the real `provisioner.build()` with a correctly-sized file across three cases:

| Entry | Result |
|---|---|
| `min_size_mb: 5` (shipped) | SKIPPED — present |
| no `min_size_mb` | RE-QUEUED — looks incomplete |
| `"min_size_mb": 0` | RE-QUEUED — looks incomplete |

That third row is the documented trap, and it is slightly worse than the docs say. `int(entry.get("min_size_mb", 0) * 1024 * 1024) or MIN_OK_SIZE` — `0` is falsy, so the provisioner falls back to 10 MiB. But the manifest still carries a literal `0`, so the *downloader's* floor really is 0. The two sides disagree: the file downloads fine and gets re-fetched forever. There is no way to express "no floor", only a lower one.

`validate_models` green at 33 entries, including the upstream existence check on the new URL. `bash -n`, `shellcheck --severity=error`, `py_compile` and a JSON parse over the repo all clean.

**Not verified:** nothing has been deployed. The download landing on a real volume at the right path is unexercised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rjpj2tmyfL3p6eJNrWR4mu
