### PR TITLE
Wan Animate on int8

### DIFF
--- a/src/models_registry.json
+++ b/src/models_registry.json
@@ -88,8 +88,8 @@
     "url": "https://huggingface.co/Comfy-Org/Wan_2.1_ComfyUI_repackaged/resolve/main/split_files/diffusion_models/wan2.1_t2v_14B_bf16.safetensors",
     "subdir": "diffusion_models"
   },
-  "wan2.2_animate_14B_bf16.safetensors": {
-    "url": "https://huggingface.co/Comfy-Org/Wan_2.2_ComfyUI_Repackaged/resolve/main/split_files/diffusion_models/wan2.2_animate_14B_bf16.safetensors",
+  "wan2.2_animate_14B_int8_convrot.safetensors": {
+    "url": "https://huggingface.co/Comfy-Org/Wan_2.2_ComfyUI_Repackaged/resolve/main/split_files/diffusion_models/wan2.2_animate_14B_int8_convrot.safetensors",
     "subdir": "diffusion_models"
   },
   "wan2.2_animate_14B_relight_lora_bf16.safetensors": {

--- a/template.json
+++ b/template.json
@@ -62,7 +62,9 @@
   "models_symlink": false,
   "custom_nodes": {
     "target": "image",
-    "repos": []
+    "repos": [
+      "https://github.com/Hearmeman24/ComfyUI-HearmemanAI-Upscale.git"
+    ]
   },
   "sage": true
 }

--- a/template.json
+++ b/template.json
@@ -62,9 +62,7 @@
   "models_symlink": false,
   "custom_nodes": {
     "target": "image",
-    "repos": [
-      "https://github.com/Hearmeman24/ComfyUI-HearmemanAI-Upscale.git"
-    ]
+    "repos": []
   },
   "sage": true
 }

--- a/workflows/Wan Animate/Wan_Animate_V2_HearmemanAI.json
+++ b/workflows/Wan Animate/Wan_Animate_V2_HearmemanAI.json
@@ -299,7 +299,7 @@
         }
       },
       "widgets_values": [
-        "wan2.2_animate_14B_bf16.safetensors",
+        "wan2.2_animate_14B_int8_convrot.safetensors",
         "default"
       ],
       "color": "#223",


### PR DESCRIPTION
Swaps the Wan Animate model for its int8 build. **Tier 2** — registry and workflow only, lands on the next pod boot, no rebuild and no tag.

| | Size |
|---|---|
| `wan2.2_animate_14B_bf16.safetensors` | **34.55 GB** |
| `wan2.2_animate_14B_int8_convrot.safetensors` | **18.41 GB** |

Measured off the Comfy-Org repo tree, not estimated. Halves the first-boot download and what has to be resident to sample.

Two places, because wan provisions in `walk` mode: the registry entry supplies the URL, and the workflow's `UNETLoader` widget is what actually puts it in the manifest. Exactly one loader referenced the old file (`Wan_Animate_V2_HearmemanAI.json`, node 226), so the workflow diff is a **single line**. Nothing else in the repo mentioned bf16.

`int8_convrot` needs `comfy-kitchen`, which ComfyUI v0.32.0 owns and the base image already installs — nothing to add to the image.

## Verified

Ran the real provisioner with `download_wan_animate=true`:

```
[provisioner] mode: walk  flags: download_wan_animate
[provisioner] models queued: 12
wan2.2_animate_14B_int8_convrot.safetensors  -> diffusion_models
```

No bf16 line survives anywhere in the manifest. `validate_models` green at 33 entries, including the upstream existence check on the new URL.

## Note on the second commit

This branch briefly also added `ComfyUI-HearmemanAI-Upscale` to `custom_nodes.repos`. That moved to comfyui-runtime#21 — the runtime now owns packs every template gets, so it is one push plus a `stable` promotion instead of four identical one-line PRs. `template.json` here is byte-identical to master again.

**Not verified:** nothing deployed. int8 sampling quality against bf16 is unmeasured, and the relight LoRA is still the bf16 build — if its strength was tuned against the bf16 base it may want a nudge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rjpj2tmyfL3p6eJNrWR4mu
