### PR TITLE
Ship taew2_1, the Wan 2.1 tiny VAE

### DIFF
--- a/src/models_registry.json
+++ b/src/models_registry.json
@@ -26,6 +26,10 @@
     "url": "https://huggingface.co/Kijai/WanVideo_comfy/resolve/main/LoRAs/Stable-Video-Infinity/v2.0/SVI_v2_PRO_Wan2.2-I2V-A14B_LOW_lora_rank_128_fp16.safetensors",
     "subdir": "loras"
   },
+  "taew2_1.pth": {
+    "url": "https://raw.githubusercontent.com/madebyollin/taehv/main/taew2_1.pth",
+    "subdir": "vae_approx"
+  },
   "Wan21_CausVid_14B_T2V_lora_rank32.safetensors": {
     "url": "https://huggingface.co/Kijai/WanVideo_comfy/resolve/main/Wan21_CausVid_14B_T2V_lora_rank32.safetensors",
     "subdir": "loras"

--- a/template.json
+++ b/template.json
@@ -9,7 +9,8 @@
       ],
       "extra_models": [
         "2xLiveActionV1_SPAN_490000.pth",
-        "rife426.pth"
+        "rife426.pth",
+        "taew2_1.pth"
       ]
     },
     "download_wan22": {
@@ -18,7 +19,8 @@
       ],
       "extra_models": [
         "2xLiveActionV1_SPAN_490000.pth",
-        "rife426.pth"
+        "rife426.pth",
+        "taew2_1.pth"
       ]
     },
     "download_wan_animate": {
@@ -28,7 +30,8 @@
       "extra_models": [
         "1x-ITF-SkinDiffDetail-Lite-v1.pth",
         "2xLiveActionV1_SPAN_490000.pth",
-        "rife426.pth"
+        "rife426.pth",
+        "taew2_1.pth"
       ]
     },
     "download_steady_dancer": {
@@ -37,7 +40,8 @@
       ],
       "extra_models": [
         "2xLiveActionV1_SPAN_490000.pth",
-        "rife426.pth"
+        "rife426.pth",
+        "taew2_1.pth"
       ]
     },
     "DOWNLOAD_SCAIL2": {
@@ -46,7 +50,8 @@
       ],
       "extra_models": [
         "2xLiveActionV1_SPAN_490000.pth",
-        "rife426.pth"
+        "rife426.pth",
+        "taew2_1.pth"
       ]
     }
   },


### PR DESCRIPTION
Adds `taew2_1.pth` from [madebyollin/taehv](https://github.com/madebyollin/taehv) into `models/vae_approx`, on every flag.

**Tier 2.** Registry + `template.json` only. Next pod boot, no rebuild, no tag.

## What uses it

WanVideoWrapper's `WanVideoTinyVAELoader`. That node lists `folder_paths.get_filename_list("vae_approx")` with **no filter at all** (`nodes_model_loading.py:1935`), so the file appears in its dropdown under this exact name, and the name is passed straight through to `TAEHV()`.

## What does not, and why that is fine

ComfyUI **core** will not surface this file. Both of its consumers match on a filename *prefix*, and `taew2_1` matches neither list:

| Consumer | Matches | Reference |
|---|---|---|
| core `VAELoader` dropdown | `v.startswith(tae)` over `["taehv", "lighttaew2_2", "lighttaew2_1", "lighttaehy1_5", "taeltx_2"]` | `nodes.py:768-780` |
| latent previewer | `fn.startswith(latent_format.taesd_decoder_name)` — `"lighttaew2_1"` for Wan 2.1 | `latent_formats.py:700`, `latent_preview.py:85-88` |

So this does **not** become the core TAESD preview decoder. That is a naming mismatch upstream, not a broken download, and the node this is for does not care. Flagging it so it does not get rediscovered as a bug later. If you ever do want core previews off it, `dest` in the manifest can land it as `lighttaew2_1.pth` — see below for why that is safe.

## The file itself

Loaded and inspected rather than assumed:

```
keys: 128
decoder.22.bias  present   -> the family gate at sd.py:885
decoder.1.weight dtype fp16 -> sd.py:901 classifies it as taehv
```

That classification is by **dtype, not filename**, so the name never changes how it loads.

## Details

- **No `min_size_mb`** — 21.6 MiB clears the 10 MiB floor on its own.
- Non-HF URL, so it routes to aria2c, which means the 2.5× free-space headroom check is skipped (known gap, `hf_download_manager.py:466`). At 22 MB that does not matter.
- `vae_approx` is a native ComfyUI category, so `start.sh` derives it, `mkdir`s it and writes it into `extra_model_paths.yaml` — no `extra_model_paths` entry needed in `template.json`.

## Verified

Real provisioner at `download_wan21=true` → queued to `vae_approx/taew2_1.pth`. `validate_models` green at 34 entries including the upstream existence check.

**Not verified:** nothing deployed. The file appearing in the `WanVideoTinyVAELoader` dropdown on a real pod is unexercised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rjpj2tmyfL3p6eJNrWR4mu
