### PR TITLE
SCAIL-2 on int8, and ship the DPO LoRA

### DIFF
--- a/src/models_registry.json
+++ b/src/models_registry.json
@@ -80,9 +80,13 @@
     "subdir": "detection",
     "min_size_mb": 0.2
   },
-  "wan2.1_14B_SCAIL_2_fp8_scaled.safetensors": {
-    "url": "https://huggingface.co/Comfy-Org/SCAIL-2/resolve/main/diffusion_models/wan2.1_14B_SCAIL_2_fp8_scaled.safetensors",
+  "wan2.1_14B_SCAIL_2_int8_convrot.safetensors": {
+    "url": "https://huggingface.co/Comfy-Org/SCAIL-2/resolve/main/diffusion_models/wan2.1_14B_SCAIL_2_int8_convrot.safetensors",
     "subdir": "diffusion_models"
+  },
+  "wan2.1_SCAIL_2_DPO_lora_bf16.safetensors": {
+    "url": "https://huggingface.co/Comfy-Org/SCAIL-2/resolve/main/loras/wan2.1_SCAIL_2_DPO_lora_bf16.safetensors",
+    "subdir": "loras"
   },
   "wan2.1_i2v_480p_14B_bf16.safetensors": {
     "url": "https://huggingface.co/Comfy-Org/Wan_2.1_ComfyUI_repackaged/resolve/main/split_files/diffusion_models/wan2.1_i2v_480p_14B_bf16.safetensors",

--- a/template.json
+++ b/template.json
@@ -51,7 +51,8 @@
       "extra_models": [
         "2xLiveActionV1_SPAN_490000.pth",
         "rife426.pth",
-        "taew2_1.pth"
+        "taew2_1.pth",
+        "wan2.1_SCAIL_2_DPO_lora_bf16.safetensors"
       ]
     }
   },

--- a/workflows/SCAIL-2/SCAIL_2_HearmemanAI.json
+++ b/workflows/SCAIL-2/SCAIL_2_HearmemanAI.json
@@ -3535,7 +3535,7 @@
         }
       },
       "widgets_values": [
-        "wan2.1_14B_SCAIL_2_fp8_scaled.safetensors",
+        "wan2.1_14B_SCAIL_2_int8_convrot.safetensors",
         "default"
       ],
       "color": "#223",


### PR DESCRIPTION
**Tier 2** — registry, `template.json` and one workflow widget. Next pod boot, no rebuild, no tag.

Replaces #20, which GitHub auto-closed when its base branch (`add-taew2-1`, now merged as #19) was deleted. Same commit, rebased onto master; the diff is the SCAIL change alone.

---

## 1. `fp8_scaled` → `int8_convrot`

Two places, because wan provisions in `walk` mode: the registry supplies the URL, and the workflow's `UNETLoader` widget is what puts it in the manifest. Exactly one loader referenced the old file (`SCAIL_2_HearmemanAI.json`, node 226), so the workflow diff is **one line**.

| | Size |
|---|---|
| `wan2.1_14B_SCAIL_2_fp8_scaled.safetensors` | 17.69 GB |
| `wan2.1_14B_SCAIL_2_int8_convrot.safetensors` | 16.65 GB |

**Not really a disk win, and worth saying so plainly** — about 1 GB. The reason to move is compute: `int8_convrot` runs on comfy-kitchen's native int8 path, which ComfyUI v0.32.0 owns and the base image already installs, while fp8 e4m3 is emulated on anything pre-Ada. So this mainly helps customers on older cards and costs nothing on newer ones.

## 2. The DPO LoRA

`wan2.1_SCAIL_2_DPO_lora_bf16.safetensors`, 1.23 GB, into `loras`, on `DOWNLOAD_SCAIL2` only.

**Nothing loads it.** The SCAIL workflow's three `LoraLoaderModelOnly` nodes are the lightx2v distill and two `Your_Character_LoRA_Here` placeholders. This is downloaded so it is on the volume when you want it, not wired in — which is why it is in `extra_models` rather than arriving through the graph.

Comfy-Org ships a `relight` LoRA in the same folder; not added here. Say the word if you want it too.

## Verified

Real provisioner at `DOWNLOAD_SCAIL2=true`:

```
[provisioner] mode: walk  flags: DOWNLOAD_SCAIL2
[provisioner] models queued: 10
  diffusion_models/wan2.1_14B_SCAIL_2_int8_convrot.safetensors
  loras/wan2.1_SCAIL_2_DPO_lora_bf16.safetensors
```

No `fp8_scaled` line survives anywhere in the repo. `validate_models` green at 35 entries, including the upstream existence check on both new URLs — sizes read off the resolve URLs, not estimated.

One process note: the workflow edit is a targeted replacement of the single quoted filename, **not** a JSON round-trip. Round-tripping this file re-encodes its existing `\uXXXX` escapes and churns the emoji in ten socket names plus a Chinese-language negative prompt. Caught it on the first pass and redid it.

**Not verified:** nothing deployed. int8 sampling quality against fp8 is unmeasured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rjpj2tmyfL3p6eJNrWR4mu

