### PR TITLE
Download the models the paid Whop workflows need

### DIFF
--- a/template.json
+++ b/template.json
@@ -31,7 +31,9 @@
         "1x-ITF-SkinDiffDetail-Lite-v1.pth",
         "2xLiveActionV1_SPAN_490000.pth",
         "rife426.pth",
-        "taew2_1.pth"
+        "taew2_1.pth",
+        "lightx2v_I2V_14B_480p_cfg_step_distill_rank64_bf16.safetensors",
+        "sam3.1_multiplex_fp16.safetensors"
       ]
     },
     "download_steady_dancer": {
@@ -52,7 +54,8 @@
         "2xLiveActionV1_SPAN_490000.pth",
         "rife426.pth",
         "taew2_1.pth",
-        "wan2.1_SCAIL_2_DPO_lora_bf16.safetensors"
+        "wan2.1_SCAIL_2_DPO_lora_bf16.safetensors",
+        "1x-ITF-SkinDiffDetail-Lite-v1.pth"
       ]
     }
   },


### PR DESCRIPTION
Wan Animate God Mode and SCAIL 2 God Mode ship behind a paywall, so they are not committed here. Walk mode builds the download manifest by scanning the workflows that **are** committed, so three models those files load were never queued. A paying customer boots a pod, drops the JSON in, and gets a missing-model dialog.

### What was missing

| flag | model | why the scan missed it |
|---|---|---|
| `download_wan_animate` | `lightx2v_I2V_14B_480p_cfg_step_distill_rank64_bf16.safetensors` | the committed V2 workflow loads `i2v_lightx2v_low_noise_model` instead, so this variant is never referenced |
| `download_wan_animate` | `sam3.1_multiplex_fp16.safetensors` | the paid workflow masks with SAM3; committed V2 is still on the SAM2 chain |
| `DOWNLOAD_SCAIL2` | `1x-ITF-SkinDiffDetail-Lite-v1.pth` | needed by the God Mode upscale pass. Already in `download_wan_animate`'s extras, absent from SCAIL-2's |

`extra_models` is the documented home for a model no committed workflow references.

### Risk

Purely additive. Nothing is removed, so pods still running the current image are unaffected, and there is no tier-2/tier-3 trap here. All three are existing registry entries.

### Verification

`comfyui-runtime/tools/validate_models.py` against this branch, network checks included:

```
🔎 verifying 35 registry files exist upstream (0 gated)...
✅ validation passed: 35 registry entries, 0 warning(s)
```

Separately confirmed against both paid workflow files that every remaining model basename and all 57 / 44 node types resolve on a wan pod (comfy-core at the pinned `v0.32.0`, packs the Dockerfile clones, or `ComfyUI-HearmemanAI-Upscale` from the runtime's `runtime_nodes.json`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KcZADLvUgdiMxgqtnHAxc4